### PR TITLE
fix: hide date placeholder when input not focused#46

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,6 +11,7 @@ code {
   font-family:
     source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+/* Fix: Hide date input placeholder when not focused */
 input[type="date"]:not(:focus)::-webkit-datetime-edit {
   color: transparent;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,3 +11,6 @@ code {
   font-family:
     source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+input[type="date"]:not(:focus)::-webkit-datetime-edit {
+  color: transparent;
+}


### PR DESCRIPTION
## 📌 Linked Issue
- [x] Connected to #46

---

## 🛠 Changes Made
- Fixed: Date input placeholder text 
  overlapping in Travel Bookings page
- Added: CSS to hide browser's default 
  date format when input is not focused

### Updated:  index.css with date input fix

---

## 🧪 Testing
- [x] Tested manually:
  - Test case 1: Open Travel Bookings page
    → Date fields show clean label only
    → Expected: No overlapping text ✅
  - Test case 2: Click on date input field
    → dd/mm/yyyy appears when focused
    → Expected: Date format visible ✅
  - Test case 3: Click away from date field
    → dd/mm/yyyy hidden when not focused
    → Expected: Clean label only ✅

---

## 📸 UI Changes
 **Before**  
<img width="1871" height="836" alt="image" src="https://github.com/user-attachments/assets/13309ad7-bb01-4b13-a664-404a858e645e" />
<img width="565" height="185" alt="image" src="https://github.com/user-attachments/assets/acb5e6cf-510b-490d-bb5d-f040630c8194" />

 
**After**
<img width="1917" height="822" alt="image" src="https://github.com/user-attachments/assets/257124c5-bf21-486f-ad48-54d8d129b515" />
<img width="552" height="240" alt="image" src="https://github.com/user-attachments/assets/bf84e553-ac10-4912-b5ee-716b0bb97cf5" />
<img width="248" height="130" alt="image" src="https://github.com/user-attachments/assets/1b19b725-ecdb-4cb0-963f-3ea6882c1502" />
<img width="270" height="142" alt="image" src="https://github.com/user-attachments/assets/33b73fee-5e7b-4637-8c7e-ea1547d3ee48" />



---

## 📝 Documentation Updates
- [x] Updated README/docs
- [x] Added code comments

---

## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have starred the repository
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes
The fix uses CSS pseudo-element selector
to hide browser's default date placeholder
when input is not focused, while keeping
it visible when user clicks the field.