### PR TITLE
fix: refresh weather widget data on dashboard revisit (#34)

### DIFF
--- a/client/src/pages/dashboard/WeatherView.js
+++ b/client/src/pages/dashboard/WeatherView.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import {
   Typography,
@@ -12,7 +12,6 @@ import {
   Divider,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
-
 import AirIcon from "@mui/icons-material/Air";
 import OpacityIcon from "@mui/icons-material/Opacity";
 import {
@@ -35,11 +34,28 @@ const getWeatherIcon = (desc) => {
 const WeatherView = () => {
   const [location, setLocation] = useState("");
   const dispatch = useDispatch();
-  const { currentWeather, forecast, loading, error } = useSelector(
+  const { currentWeather, forecast, loading, error, fetchedAt } = useSelector(
     (state) => state.weather,
   );
 
   const forecastList = forecast?.forecast || [];
+
+  // ✅ FIX: Re-fetch on every mount so data is never stale
+  useEffect(() => {
+    if (currentWeather?.location) {
+      dispatch(getCurrentWeather(currentWeather.location));
+      dispatch(getForecast(currentWeather.location));
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ✅ Manual refresh handler
+  const handleRefresh = useCallback(() => {
+    const city = location.trim() || currentWeather?.location;
+    if (city) {
+      dispatch(getCurrentWeather(city));
+      dispatch(getForecast(city));
+    }
+  }, [dispatch, location, currentWeather]);
 
   const handleSearch = (e) => {
     e.preventDefault();
@@ -224,9 +240,26 @@ const WeatherView = () => {
                 </Typography>
               )}
               <Box sx={{ mt: "auto", pt: 3 }}>
+                {/* ✅ Real fetchedAt timestamp */}
                 <Typography variant="caption" color="text.disabled">
-                  Last updated: {new Date().toLocaleTimeString()}
+                  Last updated:{" "}
+                  {fetchedAt
+                    ? new Date(fetchedAt).toLocaleTimeString()
+                    : "—"}
                 </Typography>
+
+                {/* ✅ Manual refresh button */}
+                <Box mt={1}>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={handleRefresh}
+                    disabled={loading}
+                    sx={{ borderRadius: 2 }}
+                  >
+                    {loading ? "Refreshing..." : "🔄 Refresh"}
+                  </Button>
+                </Box>
               </Box>
             </Paper>
           </Grid>

--- a/client/src/redux/reducers/weatherReducer.js
+++ b/client/src/redux/reducers/weatherReducer.js
@@ -11,6 +11,7 @@ const initialState = {
   forecast: null,
   loading: false,
   error: null,
+  fetchedAt: null,
 };
 
 export default function weatherReducer(state = initialState, action) {
@@ -25,6 +26,7 @@ export default function weatherReducer(state = initialState, action) {
         ...state,
         currentWeather: action.payload,
         loading: false,
+        fetchedAt: new Date().toISOString(),
       };
     case GET_FORECAST:
       return {


### PR DESCRIPTION
## Description
Fixes #34 - Weather widget showed stale cached data after navigating back to the dashboard.

### Changes made:
- Added re-fetching of weather data when dashboard loads again
- Added `fetchedAt` timestamp to indicate when data was last updated
- Ensured users can verify whether weather information is current
- Improved freshness visibility for the weather widget

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows project guidelines
- [x] I tested my changes locally
- [x] I have linked the related issue
- [x] My changes do not break existing functionality

## Related Issue
Closes #34