### PR TITLE
feat: add tooltips to dashboard sidebar icons (#58)

### DIFF
--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -174,8 +174,8 @@ const Dashboard = () => {
       {/* Nav Items */}
       <List sx={{ flexGrow: 1, pt: 1, px: 1 }}>
         {menuItems.map((item) => (
-          <Tooltip title={item.text} placement="right" arrow key={item.text}>
-            <ListItem disablePadding sx={{ mb: 0.5 }}>
+          <ListItem key={item.text} disablePadding sx={{ mb: 0.5 }}>
+            <Tooltip title={item.text} placement="right" arrow>
               <ListItemButton
                 component={Link}
                 to={`/dashboard/${item.path}`}
@@ -209,8 +209,8 @@ const Dashboard = () => {
                   }}
                 />
               </ListItemButton>
-            </ListItem>
-          </Tooltip>
+            </Tooltip>
+          </ListItem>
         ))}
       </List>   
 

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -212,7 +212,7 @@ const Dashboard = () => {
             </Tooltip>
           </ListItem>
         ))}
-      </List>   
+      </List>
 
       <Divider />
       <List sx={{ px: 1, pb: 1 }}>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -174,39 +174,45 @@ const Dashboard = () => {
       {/* Nav Items */}
       <List sx={{ flexGrow: 1, pt: 1, px: 1 }}>
         {menuItems.map((item) => (
-          <ListItem key={item.text} disablePadding sx={{ mb: 0.5 }}>
-            <ListItemButton
-              component={Link}
-              to={`/dashboard/${item.path}`}
-              onClick={() => setMobileOpen(false)}
-              selected={isActive(item.path)}
-              sx={{
-                borderRadius: 2.5,
-                "&.Mui-selected": {
-                  bgcolor: "primary.main",
-                  color: "white",
-                  "& .MuiListItemIcon-root": { color: "white" },
-                  "&:hover": { bgcolor: "primary.dark" },
-                },
-                "&:hover": { bgcolor: "rgba(63, 81, 181, 0.08)" },
-              }}
-            >
-              <ListItemIcon
+          <Tooltip title={item.text} placement="right" arrow key={item.text}>
+            <ListItem disablePadding sx={{ mb: 0.5 }}>
+              <ListItemButton
+                component={Link}
+                to={`/dashboard/${item.path}`}
+                onClick={() => setMobileOpen(false)}
+                selected={isActive(item.path)}
                 sx={{
-                  minWidth: 40,
-                  color: isActive(item.path) ? "white" : "text.secondary",
+                  borderRadius: 2.5,
+                  "&.Mui-selected": {
+                    bgcolor: "primary.main",
+                    color: "white",
+                    "& .MuiListItemIcon-root": { color: "white" },
+                    "&:hover": { bgcolor: "primary.dark" },
+                  },
+                  "&:hover": { bgcolor: "rgba(63, 81, 181, 0.08)" },
                 }}
               >
-                {item.icon}
-              </ListItemIcon>
-              <ListItemText
-                primary={item.text}
-                primaryTypographyProps={{ fontWeight: 600, fontSize: "0.9rem" }}
-              />
-            </ListItemButton>
-          </ListItem>
+                <ListItemIcon
+                  sx={{
+                    minWidth: 40,
+                    color: isActive(item.path) ? "white" : "text.secondary",
+                  }}
+                >
+                  {item.icon}
+                </ListItemIcon>
+
+                <ListItemText
+                  primary={item.text}
+                  primaryTypographyProps={{
+                    fontWeight: 600,
+                    fontSize: "0.9rem",
+                  }}
+                />
+              </ListItemButton>
+            </ListItem>
+          </Tooltip>
         ))}
-      </List>
+      </List>   
 
       <Divider />
       <List sx={{ px: 1, pb: 1 }}>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -864,55 +864,55 @@ const Home = () => {
       </div>
 
       {/* ═══ FOOTER ═══ */}
-     <footer className="wander-footer">
-  <div className="wander-footer-top">
-    <div className="wander-footer-brand">
-      <Link to="/" className="wander-footer-logo">
-        Pack<span>Go</span>
-      </Link>
+      <footer className="wander-footer">
+        <div className="wander-footer-top">
+          <div className="wander-footer-brand">
+            <Link to="/" className="wander-footer-logo">
+              Pack<span>Go</span>
+            </Link>
 
-      <p>
-        Discover breathtaking destinations, curated travel experiences,
-        and unforgettable journeys with PackGo Travel.
-      </p>
-    </div>
+            <p>
+              Discover breathtaking destinations, curated travel experiences,
+              and unforgettable journeys with PackGo Travel.
+            </p>
+          </div>
 
-    <div className="wander-footer-links-wrapper">
-      <div className="wander-footer-col">
-        <h4>Explore</h4>
-        <a href="#wander-dest-section">Destinations</a>
-        <a href="#wander-features">Experiences</a>
-        <a href="#wander-features">Features</a>
-      </div>
+          <div className="wander-footer-links-wrapper">
+            <div className="wander-footer-col">
+              <h4>Explore</h4>
+              <a href="#wander-dest-section">Destinations</a>
+              <a href="#wander-features">Experiences</a>
+              <a href="#wander-features">Features</a>
+            </div>
 
-      <div className="wander-footer-col">
-        <h4>Company</h4>
-        <a href="/">About</a>
-        <a href="/">Careers</a>
-        <a href="/">Contact</a>
-      </div>
+            <div className="wander-footer-col">
+              <h4>Company</h4>
+              <a href="/">About</a>
+              <a href="/">Careers</a>
+              <a href="/">Contact</a>
+            </div>
 
-      <div className="wander-footer-col">
-        <h4>Support</h4>
-        <a href="/">Help Center</a>
-        <a href="/">Privacy Policy</a>
-        <a href="/">Terms & Conditions</a>
-      </div>
-    </div>
-  </div>
+            <div className="wander-footer-col">
+              <h4>Support</h4>
+              <a href="/">Help Center</a>
+              <a href="/">Privacy Policy</a>
+              <a href="/">Terms & Conditions</a>
+            </div>
+          </div>
+        </div>
 
-  <div className="wander-footer-bottom">
-    <div className="wander-footer-copy">
-      © {new Date().getFullYear()} PackGo Travel Co. All rights reserved.
-    </div>
+        <div className="wander-footer-bottom">
+          <div className="wander-footer-copy">
+            © {new Date().getFullYear()} PackGo Travel Co. All rights reserved.
+          </div>
 
-    <div className="wander-footer-socials">
-      <a href="/">FB</a>
-      <a href="/">IG</a>
-      <a href="/">TW</a>
-    </div>
-  </div>
-</footer>
+          <div className="wander-footer-socials">
+            <a href="/">FB</a>
+            <a href="/">IG</a>
+            <a href="/">TW</a>
+          </div>
+        </div>
+      </footer>
     </div>
   );
 };


### PR DESCRIPTION
## Related Issue
Closes #58

---

## Description
Added Material UI tooltips to all dashboard sidebar icons to improve navigation and accessibility.

### Changes Made
- Added `Tooltip` component to sidebar navigation icons
- Fixed tooltip wrapper structure
- Improved ListItem and Tooltip nesting
- Ensured tooltips display correctly on hover
- Maintained responsive sidebar layout
- Applied Prettier formatting fixes

---

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Screenshots
<img width="751" height="947" alt="Screenshot 2026-05-16 004604" src="https://github.com/user-attachments/assets/7df2daff-d909-4b86-b237-4c52eafc9de2" />


---

## Checklist
- [x] Code builds successfully
- [x] Formatting checked with Prettier
- [x] No console errors
- [x] Existing functionality preserved
- [x] Responsive UI maintained