### PR TITLE
Fix: Log In button clipped on mobile in CTA section

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -870,5 +870,11 @@
   }
   .wander-cta-actions {
     flex-direction: column;
+    width: 100%;
+  }
+  .wander-btn-primary,
+  .wander-btn-ghost {
+    width: 100%;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## 📌 Linked Issue
- [x] Connected to #64

## 🛠 Changes Made
- Fixed: Added `flex-direction: column` and `width: 100%` 
  to `.wander-cta-actions` inside `@media (max-width: 900px)`
- Fixed: Added `width: 100%` and `text-align: center` to 
  `.wander-btn-primary` and `.wander-btn-ghost` for mobile screens

## 🧪 Testing
- [x] Tested manually (describe below):
  - Test case 1: Opened the app on mobile view (Chrome DevTools) 
    — both buttons are now fully visible and stacked vertically
  - Test case 2: Verified desktop view is unaffected — buttons 
    still appear side by side

## 📸 UI Changes (if applicable)
| Before  | After   |
| ------- | ------- |
| <img width="640" height="1400" alt="WhatsApp Image 2026-05-16 at 06 59 19" src="https://github.com/user-attachments/assets/d81dcd41-a5fd-46c7-a5d1-dd628cd5d7cf" /> | <img width="421" height="571" alt="Screenshot 2026-05-17 100429" src="https://github.com/user-attachments/assets/b4e09945-02ef-445f-984f-ae113c90d4e8" /> |

## 📝 Documentation Updates
- [ ] Not required for this fix

## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have stared the repository
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes
Fixed in `client/src/pages/Home.css` — 
the `.wander-cta-actions` class was missing 
responsive rules inside the 
`@media (max-width: 900px)` block