### PR TITLE
docs: clarify separate client and server setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,19 @@ cd travel-planner
 
 ### 2. Install Dependencies
 
+> ⚠️ **Important:**  
+> This repository uses separate frontend (`client`) and backend (`server`) environments.
+>
+> Running commands like:
+>
+> ```bash
+> npm run dev
+> ```
+>
+> from the root directory will result in a missing script error.
+>
+> Please install dependencies and run scripts separately inside the `client` and `server` directories.
+
 ```bash
 # Install backend dependencies
 cd server


### PR DESCRIPTION
## Description

Improved the README setup instructions by clarifying the separate frontend and backend development workflow.

Many contributors may attempt to run:

```bash
npm run dev
```

from the root directory, which results in a missing script error because the root only contains project-level configuration scripts.

## Changes Made

* Added an important setup note in the README
* Clarified that frontend and backend environments are independent
* Explained that dependencies and scripts must be run separately inside:

  * `client/`
  * `server/`
* Reduced onboarding confusion for new contributors

## Files Modified

* `README.md`

## Type of Change

* Documentation Improvement
* Contributor Onboarding Enhancement

## Issue Fixed

Clarifies local setup flow and prevents confusion caused by missing root-level scripts.
