### PR TITLE
feat: Add Recently Viewed Destinations Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ Whether you're planning a weekend getaway or a month-long adventure, PackGo keep
 - Quick action cards for navigation
 - Upcoming trip cards with status badges
 
+### 🕐 Recently Viewed Destinations
+
+- Tracks the last **5 destinations** you explored on the home page
+- Persists across page refreshes using **localStorage**
+- Horizontally scrollable cards with destination image, name, and location
+- One-click to jump back to a destination
+- **Clear all** button to reset history
+- No duplicates — revisiting a destination moves it to the top
+
 ---
 
 ## 🛠️ Tech Stack

--- a/client/src/components/RecentlyViewed.js
+++ b/client/src/components/RecentlyViewed.js
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react';
+import { getRecentlyViewed, clearRecentlyViewed } from '../utils/recentlyViewed';
+
+const RecentlyViewed = ({ onSelectDestination }) => {
+  const [destinations, setDestinations] = useState([]);
+
+  useEffect(() => {
+    setDestinations(getRecentlyViewed());
+  }, []);
+
+  const handleClear = () => {
+    clearRecentlyViewed();
+    setDestinations([]);
+  };
+
+  if (destinations.length === 0) return null;
+
+  return (
+    <div style={{ marginTop: '2rem', marginBottom: '1rem' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span style={{ fontSize: '1.2rem' }}>🕐</span>
+          <h3 style={{ margin: 0, fontSize: '1.1rem', fontWeight: 700, color: '#1A4A6B' }}>
+            Recently Viewed
+          </h3>
+          <span style={{
+            background: '#1A4A6B', color: 'white',
+            borderRadius: '999px', padding: '2px 8px', fontSize: '0.75rem', fontWeight: 600
+          }}>
+            {destinations.length}
+          </span>
+        </div>
+        <button
+          onClick={handleClear}
+          style={{
+            background: 'none', border: '1px solid #e0e0e0',
+            borderRadius: '6px', padding: '4px 10px',
+            cursor: 'pointer', fontSize: '0.78rem', color: '#888'
+          }}
+        >
+          Clear all
+        </button>
+      </div>
+
+      {/* Scrollable Cards Row */}
+      <div style={{
+        display: 'flex', gap: '1rem',
+        overflowX: 'auto', paddingBottom: '0.5rem',
+        scrollbarWidth: 'thin',
+      }}>
+        {destinations.map((dest) => (
+          <div
+            key={dest._id}
+            onClick={() => onSelectDestination && onSelectDestination(dest)}
+            style={{
+              minWidth: '160px', maxWidth: '160px',
+              borderRadius: '12px', overflow: 'hidden',
+              boxShadow: '0 2px 10px rgba(0,0,0,0.1)',
+              cursor: 'pointer', flexShrink: 0,
+              background: 'white',
+              transition: 'transform 0.2s, box-shadow 0.2s',
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.transform = 'translateY(-4px)';
+              e.currentTarget.style.boxShadow = '0 8px 20px rgba(0,0,0,0.15)';
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.transform = 'translateY(0)';
+              e.currentTarget.style.boxShadow = '0 2px 10px rgba(0,0,0,0.1)';
+            }}
+          >
+            {/* Image */}
+            <div style={{ height: '100px', background: 'linear-gradient(135deg, #1A4A6B, #2D7D9A)', position: 'relative', overflow: 'hidden' }}>
+              {dest.images?.[0] && (
+                <img
+                  src={dest.images[0]}
+                  alt={dest.name}
+                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                  onError={e => { e.target.style.display = 'none'; }}
+                />
+              )}
+              <div style={{
+                position: 'absolute', bottom: '6px', right: '6px',
+                background: 'rgba(0,0,0,0.5)', color: 'white',
+                borderRadius: '4px', padding: '2px 6px', fontSize: '0.7rem'
+              }}>
+                {dest.rating ? `⭐ ${dest.rating}` : '📍'}
+              </div>
+            </div>
+            {/* Info */}
+            <div style={{ padding: '0.6rem 0.75rem' }}>
+              <div style={{ fontWeight: 700, fontSize: '0.85rem', color: '#1A4A6B', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {dest.name}
+              </div>
+              <div style={{ fontSize: '0.72rem', color: '#888', marginTop: '2px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {[dest.city, dest.state].filter(Boolean).join(', ')}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RecentlyViewed;

--- a/client/src/components/RecentlyViewed.js
+++ b/client/src/components/RecentlyViewed.js
@@ -1,5 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { getRecentlyViewed, clearRecentlyViewed } from '../utils/recentlyViewed';
+import React, { useState, useEffect } from "react";
+import {
+  getRecentlyViewed,
+  clearRecentlyViewed,
+} from "../utils/recentlyViewed";
 
 const RecentlyViewed = ({ onSelectDestination }) => {
   const [destinations, setDestinations] = useState([]);
@@ -16,27 +19,51 @@ const RecentlyViewed = ({ onSelectDestination }) => {
   if (destinations.length === 0) return null;
 
   return (
-    <div style={{ marginTop: '2rem', marginBottom: '1rem' }}>
+    <div style={{ marginTop: "2rem", marginBottom: "1rem" }}>
       {/* Header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <span style={{ fontSize: '1.2rem' }}>🕐</span>
-          <h3 style={{ margin: 0, fontSize: '1.1rem', fontWeight: 700, color: '#1A4A6B' }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "1rem",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          <span style={{ fontSize: "1.2rem" }}>🕐</span>
+          <h3
+            style={{
+              margin: 0,
+              fontSize: "1.1rem",
+              fontWeight: 700,
+              color: "#1A4A6B",
+            }}
+          >
             Recently Viewed
           </h3>
-          <span style={{
-            background: '#1A4A6B', color: 'white',
-            borderRadius: '999px', padding: '2px 8px', fontSize: '0.75rem', fontWeight: 600
-          }}>
+          <span
+            style={{
+              background: "#1A4A6B",
+              color: "white",
+              borderRadius: "999px",
+              padding: "2px 8px",
+              fontSize: "0.75rem",
+              fontWeight: 600,
+            }}
+          >
             {destinations.length}
           </span>
         </div>
         <button
           onClick={handleClear}
           style={{
-            background: 'none', border: '1px solid #e0e0e0',
-            borderRadius: '6px', padding: '4px 10px',
-            cursor: 'pointer', fontSize: '0.78rem', color: '#888'
+            background: "none",
+            border: "1px solid #e0e0e0",
+            borderRadius: "6px",
+            padding: "4px 10px",
+            cursor: "pointer",
+            fontSize: "0.78rem",
+            color: "#888",
           }}
         >
           Clear all
@@ -44,57 +71,98 @@ const RecentlyViewed = ({ onSelectDestination }) => {
       </div>
 
       {/* Scrollable Cards Row */}
-      <div style={{
-        display: 'flex', gap: '1rem',
-        overflowX: 'auto', paddingBottom: '0.5rem',
-        scrollbarWidth: 'thin',
-      }}>
+      <div
+        style={{
+          display: "flex",
+          gap: "1rem",
+          overflowX: "auto",
+          paddingBottom: "0.5rem",
+          scrollbarWidth: "thin",
+        }}
+      >
         {destinations.map((dest) => (
           <div
             key={dest._id}
             onClick={() => onSelectDestination && onSelectDestination(dest)}
             style={{
-              minWidth: '160px', maxWidth: '160px',
-              borderRadius: '12px', overflow: 'hidden',
-              boxShadow: '0 2px 10px rgba(0,0,0,0.1)',
-              cursor: 'pointer', flexShrink: 0,
-              background: 'white',
-              transition: 'transform 0.2s, box-shadow 0.2s',
+              minWidth: "160px",
+              maxWidth: "160px",
+              borderRadius: "12px",
+              overflow: "hidden",
+              boxShadow: "0 2px 10px rgba(0,0,0,0.1)",
+              cursor: "pointer",
+              flexShrink: 0,
+              background: "white",
+              transition: "transform 0.2s, box-shadow 0.2s",
             }}
-            onMouseEnter={e => {
-              e.currentTarget.style.transform = 'translateY(-4px)';
-              e.currentTarget.style.boxShadow = '0 8px 20px rgba(0,0,0,0.15)';
+            onMouseEnter={(e) => {
+              e.currentTarget.style.transform = "translateY(-4px)";
+              e.currentTarget.style.boxShadow = "0 8px 20px rgba(0,0,0,0.15)";
             }}
-            onMouseLeave={e => {
-              e.currentTarget.style.transform = 'translateY(0)';
-              e.currentTarget.style.boxShadow = '0 2px 10px rgba(0,0,0,0.1)';
+            onMouseLeave={(e) => {
+              e.currentTarget.style.transform = "translateY(0)";
+              e.currentTarget.style.boxShadow = "0 2px 10px rgba(0,0,0,0.1)";
             }}
           >
             {/* Image */}
-            <div style={{ height: '100px', background: 'linear-gradient(135deg, #1A4A6B, #2D7D9A)', position: 'relative', overflow: 'hidden' }}>
+            <div
+              style={{
+                height: "100px",
+                background: "linear-gradient(135deg, #1A4A6B, #2D7D9A)",
+                position: "relative",
+                overflow: "hidden",
+              }}
+            >
               {dest.images?.[0] && (
                 <img
                   src={dest.images[0]}
                   alt={dest.name}
-                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-                  onError={e => { e.target.style.display = 'none'; }}
+                  style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                  onError={(e) => {
+                    e.target.style.display = "none";
+                  }}
                 />
               )}
-              <div style={{
-                position: 'absolute', bottom: '6px', right: '6px',
-                background: 'rgba(0,0,0,0.5)', color: 'white',
-                borderRadius: '4px', padding: '2px 6px', fontSize: '0.7rem'
-              }}>
-                {dest.rating ? `⭐ ${dest.rating}` : '📍'}
+              <div
+                style={{
+                  position: "absolute",
+                  bottom: "6px",
+                  right: "6px",
+                  background: "rgba(0,0,0,0.5)",
+                  color: "white",
+                  borderRadius: "4px",
+                  padding: "2px 6px",
+                  fontSize: "0.7rem",
+                }}
+              >
+                {dest.rating ? `⭐ ${dest.rating}` : "📍"}
               </div>
             </div>
             {/* Info */}
-            <div style={{ padding: '0.6rem 0.75rem' }}>
-              <div style={{ fontWeight: 700, fontSize: '0.85rem', color: '#1A4A6B', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            <div style={{ padding: "0.6rem 0.75rem" }}>
+              <div
+                style={{
+                  fontWeight: 700,
+                  fontSize: "0.85rem",
+                  color: "#1A4A6B",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
                 {dest.name}
               </div>
-              <div style={{ fontSize: '0.72rem', color: '#888', marginTop: '2px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                {[dest.city, dest.state].filter(Boolean).join(', ')}
+              <div
+                style={{
+                  fontSize: "0.72rem",
+                  color: "#888",
+                  marginTop: "2px",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {[dest.city, dest.state].filter(Boolean).join(", ")}
               </div>
             </div>
           </div>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -5,6 +5,9 @@ import "./Home.css";
 import api from "../services/api";
 import { addTrip } from "../redux/actions/tripActions";
 import { FaFacebook, FaInstagram, FaTwitter } from "react-icons/fa";
+import RecentlyViewed from '../components/RecentlyViewed';
+import { addRecentlyViewed } from '../utils/recentlyViewed';
+
 /* ── SVG SCENES ─────────────────────────────────────────────── */
 const SceneIceland = () => (
   <svg
@@ -383,10 +386,14 @@ const Home = () => {
   }, []);
 
   const handleAddTrip = (dest) => {
+    // Save to recently viewed regardless of auth status
+    addRecentlyViewed(dest);  // ← MOVE THIS to the top, before the auth check
+
     if (!isAuthenticated) {
       navigate("/login");
       return;
     }
+    
     const today = new Date(),
       next = new Date();
     next.setDate(today.getDate() + 7);
@@ -660,6 +667,19 @@ const Home = () => {
       </div>
 
       {/* ═══ DESTINATIONS ═══ */}
+
+      {/* ═══ RECENTLY VIEWED ═══ */}
+      <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 1.5rem' }}>
+        <RecentlyViewed
+          onSelectDestination={(dest) => {
+            document
+              .getElementById("wander-dest-section")
+              ?.scrollIntoView({ behavior: "smooth" });
+            setWhere(dest.name);
+          }}
+        />
+      </div>
+
       <section className="wander-section" id="wander-dest-section">
         <div className="wander-section-header">
           <div>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -5,8 +5,8 @@ import "./Home.css";
 import api from "../services/api";
 import { addTrip } from "../redux/actions/tripActions";
 import { FaFacebook, FaInstagram, FaTwitter } from "react-icons/fa";
-import RecentlyViewed from '../components/RecentlyViewed';
-import { addRecentlyViewed } from '../utils/recentlyViewed';
+import RecentlyViewed from "../components/RecentlyViewed";
+import { addRecentlyViewed } from "../utils/recentlyViewed";
 
 /* ── SVG SCENES ─────────────────────────────────────────────── */
 const SceneIceland = () => (
@@ -387,13 +387,13 @@ const Home = () => {
 
   const handleAddTrip = (dest) => {
     // Save to recently viewed regardless of auth status
-    addRecentlyViewed(dest);  // ← MOVE THIS to the top, before the auth check
+    addRecentlyViewed(dest); // ← MOVE THIS to the top, before the auth check
 
     if (!isAuthenticated) {
       navigate("/login");
       return;
     }
-    
+
     const today = new Date(),
       next = new Date();
     next.setDate(today.getDate() + 7);
@@ -669,7 +669,9 @@ const Home = () => {
       {/* ═══ DESTINATIONS ═══ */}
 
       {/* ═══ RECENTLY VIEWED ═══ */}
-      <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 1.5rem' }}>
+      <div
+        style={{ maxWidth: "1200px", margin: "0 auto", padding: "0 1.5rem" }}
+      >
         <RecentlyViewed
           onSelectDestination={(dest) => {
             document

--- a/client/src/utils/recentlyViewed.js
+++ b/client/src/utils/recentlyViewed.js
@@ -1,0 +1,27 @@
+const KEY = 'recently_viewed_destinations';
+const MAX_ITEMS = 5;
+
+export function getRecentlyViewed() {
+  try {
+    const data = localStorage.getItem(KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addRecentlyViewed(destination) {
+  try {
+    let list = getRecentlyViewed();
+    list = list.filter((item) => item._id !== destination._id);
+    list.unshift(destination);
+    if (list.length > MAX_ITEMS) list = list.slice(0, MAX_ITEMS);
+    localStorage.setItem(KEY, JSON.stringify(list));
+  } catch (err) {
+    console.error('Failed to save recently viewed:', err);
+  }
+}
+
+export function clearRecentlyViewed() {
+  localStorage.removeItem(KEY);
+}

--- a/client/src/utils/recentlyViewed.js
+++ b/client/src/utils/recentlyViewed.js
@@ -1,4 +1,4 @@
-const KEY = 'recently_viewed_destinations';
+const KEY = "recently_viewed_destinations";
 const MAX_ITEMS = 5;
 
 export function getRecentlyViewed() {
@@ -18,7 +18,7 @@ export function addRecentlyViewed(destination) {
     if (list.length > MAX_ITEMS) list = list.slice(0, MAX_ITEMS);
     localStorage.setItem(KEY, JSON.stringify(list));
   } catch (err) {
-    console.error('Failed to save recently viewed:', err);
+    console.error("Failed to save recently viewed:", err);
   }
 }
 

--- a/server/utils/recentlyViewed.js
+++ b/server/utils/recentlyViewed.js
@@ -1,0 +1,36 @@
+const KEY = 'recently_viewed_destinations';
+const MAX_ITEMS = 5;
+
+export function getRecentlyViewed() {
+  try {
+    const data = localStorage.getItem(KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addRecentlyViewed(destination) {
+  try {
+    let list = getRecentlyViewed();
+
+    // Remove duplicate if exists
+    list = list.filter((item) => item._id !== destination._id);
+
+    // Add to front
+    list.unshift(destination);
+
+    // Keep max 5
+    if (list.length > MAX_ITEMS) {
+      list = list.slice(0, MAX_ITEMS);
+    }
+
+    localStorage.setItem(KEY, JSON.stringify(list));
+  } catch (err) {
+    console.error('Failed to save recently viewed:', err);
+  }
+}
+
+export function clearRecentlyViewed() {
+  localStorage.removeItem(KEY);
+}

--- a/server/utils/recentlyViewed.js
+++ b/server/utils/recentlyViewed.js
@@ -1,4 +1,4 @@
-const KEY = 'recently_viewed_destinations';
+const KEY = "recently_viewed_destinations";
 const MAX_ITEMS = 5;
 
 export function getRecentlyViewed() {
@@ -27,7 +27,7 @@ export function addRecentlyViewed(destination) {
 
     localStorage.setItem(KEY, JSON.stringify(list));
   } catch (err) {
-    console.error('Failed to save recently viewed:', err);
+    console.error("Failed to save recently viewed:", err);
   }
 }
 


### PR DESCRIPTION
name: "📦 Pull Request"
about: Submit changes for review
title: "PR: [Brief Description]"
labels: ""
assignees: ""
---

## 📌 Linked Issue

- [x] Connected to #283

---

## 🛠 Changes Made

- Added: `client/src/utils/recentlyViewed.js` — localStorage utility with get, add, and clear functions
- Added: `client/src/components/RecentlyViewed.js` — horizontally scrollable destination cards component
- Updated: `client/src/pages/Home.js` — integrated `addRecentlyViewed()` on destination click and rendered `<RecentlyViewed />` section between search bar and destinations grid

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually:
  - Test case 1: Click a destination card → go back to Home → "Recently Viewed" strip appears with the clicked destination ✅
  - Test case 2: Click 6+ destinations → only the latest 5 are shown (oldest drops off) ✅
  - Test case 3: Refresh the page → Recently Viewed destinations persist (localStorage) ✅
  - Test case 4: Click the same destination twice → no duplicates shown ✅
  - Test case 5: Click "Clear all" button → section disappears and history is wiped ✅

---

## 📸 UI Changes (if applicable)

| Before | After |
| ------ | ----- |
| No recently viewed section existed | Horizontally scrollable "Recently Viewed" strip appears above the destinations grid after visiting any destination |

<!-- Add your before/after screenshots here -->

Before:

<img width="1897" height="911" alt="image" src="https://github.com/user-attachments/assets/29a289b3-4884-4aaa-853b-161cc9771766" />

After:

<img width="1896" height="906" alt="image" src="https://github.com/user-attachments/assets/397d41d6-d926-4c32-ba7b-404ebc36ecba" />

---

## 📝 Documentation Updates

- [x] Updated README/docs
- [x] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have stared the repository
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

---

## 💡 Additional Notes

- The Recently Viewed section only renders when there is at least one viewed destination — it returns `null` when empty, so it doesn't affect the layout for first-time visitors
- Uses localStorage so no backend changes were needed
- Maximum of 5 destinations stored, with automatic deduplication