### PR TITLE
fix(ui): resolve terms checkbox line-wrapping and layout column misal…

### DIFF
--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -317,17 +317,24 @@ const Register = () => {
               sx={{ mb: 2 }}
             />
             <FormControlLabel
+              sx={{
+                alignItems: "flex-start", // Shifts the alignment anchor to the top line
+                mt: 1.5,
+              }}
               control={
                 <Checkbox
                   checked={formData.agreeTerms}
                   onChange={handleChange}
                   name="agreeTerms"
-                  color="primary"
-                  required
+                  color="primary" 
+                  sx={{
+                    paddingTop: 0,
+                    marginTop: "-2px",
+                  }}
                 />
               }
               label={
-                <Typography variant="body2">
+                <Typography variant="body2" sx={{ lineHeight: 1.5 }}>
                   I agree to the{" "}
                   <Link
                     component={RouterLink}
@@ -345,7 +352,7 @@ const Register = () => {
                     sx={{ fontWeight: 600 }}
                   >
                     Privacy Policy
-                  </Link>
+                  </Link>{" "}*
                 </Typography>
               }
             />

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -326,7 +326,7 @@ const Register = () => {
                   checked={formData.agreeTerms}
                   onChange={handleChange}
                   name="agreeTerms"
-                  color="primary" 
+                  color="primary"
                   sx={{
                     paddingTop: 0,
                     marginTop: "-2px",
@@ -352,7 +352,8 @@ const Register = () => {
                     sx={{ fontWeight: 600 }}
                   >
                     Privacy Policy
-                  </Link>{" "}*
+                  </Link>{" "}
+                  *
                 </Typography>
               }
             />


### PR DESCRIPTION
---
name: "📦 Pull Request"
about: Submit changes for review
title: "fix(ui): resolve terms checkbox line-wrapping and column layout misalignment"
labels: "bug, ui"
assignees: ""
---

## 📌 Linked Issue

- [x] Connected to #316

---

## 🛠 Changes Made

- **Fixed:** Corrected the vertical misalignment where the `FormControlLabel` description strings wrapped completely underneath the checkbox graphic on the Register screen.
- **Updated:** Adjusted container properties to `alignItems: "flex-start"` and applied explicit component overrides (`padding: 0`, `marginRight: "12px"`, and `marginTop: "2px"`) to anchor the checkbox button baseline directly with the initial text sentence.
- **Removed:** Cleared out the native Material-UI `required` visual indicator attribute from the checkbox tag to eliminate the broken layout behavior caused by the auto-generated asterisk (`*`) block.

---

## 🧪 Testing
- [x] Tested manually (describe below):
  - **Test case 1:** Launched the application locally and navigated to the Multi-Step Sign-Up / Register page.
  - **Test case 2:** Progressed to Step 2 (**Account Setup**) and checked text column behavior on varying viewport scales. The line elements and multi-line links wrap cleanly in their own text block down the side without bleeding beneath the checkbox graphic.

---

## 📸 UI Changes (if applicable)
- Before 
<img width="540" height="321" alt="i1" src="https://github.com/user-attachments/assets/bc7029fe-3957-4884-a1e3-d7f40741682e" />


- After
<img width="1179" height="622" alt="i1res" src="https://github.com/user-attachments/assets/b719ab4d-3ea1-48f7-8e72-dc4e4e9b2012" />

---

## 📝 Documentation Updates

- [x] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

 