### PR TITLE
Fix overlapping calendar icon in check-in date field

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -628,20 +628,7 @@ const Home = () => {
                 type="date"
                 value={checkIn}
                 onChange={(e) => setCheckIn(e.target.value)}
-                style={{ paddingRight: "35px" }}
               />
-
-              <span
-                style={{
-                  position: "absolute",
-                  right: "10px",
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  pointerEvents: "none",
-                }}
-              >
-                📅
-              </span>
             </div>
           </div>
           <div className="wander-sf">


### PR DESCRIPTION
## Description

Resolved the overlapping calendar icon issue in the check-in date input.

### Changes made

* Removed manually added calendar emoji icon.
* Removed extra right padding associated with the custom icon.
* Kept the native browser date picker icon.

### Testing

Verified locally using `npm start`.
The date input now renders correctly without duplicate/overlapping icons.
>
