### PR TITLE
Bug: website footer looks unprofessional, footer layout has improper spacing and alignment issues

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -749,49 +749,6 @@ html {
 /* ═══ FOOTER ═══ */
 .wander-footer {
   background: var(--dark);
-  color: rgba(253, 250, 245, 0.5);
-  padding: 3rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
-.wander-footer-logo {
-  font-family: "Playfair Display", serif;
-  font-size: 1.2rem;
-  color: var(--white);
-  text-decoration: none;
-}
-
-.wander-footer-logo span {
-  color: var(--coral);
-}
-
-.wander-footer-links {
-  display: flex;
-  gap: 2rem;
-}
-
-.wander-footer-links a {
-  color: rgba(253, 250, 245, 0.4);
-  font-size: 0.82rem;
-  text-decoration: none;
-  transition: color 0.2s;
-}
-
-.wander-footer-links a:hover {
-  color: rgba(253, 250, 245, 0.8);
-}
-
-.wander-footer-copy {
-  font-size: 0.78rem;
-}
-
-/* ═══ FOOTER ═══ */
-.wander-footer {
-  background: var(--dark);
   color: rgba(253, 250, 245, 0.7);
   padding: 4rem 3rem 2rem;
   display: flex;
@@ -987,7 +944,6 @@ html {
 
   .wander-footer {
     padding: 2rem 1.5rem;
-    flex-direction: column;
     text-align: center;
   }
 


### PR DESCRIPTION
## Description
Removes duplicated `.wander-footer` CSS block and unused `.wander-footer-links` styles that caused improper spacing and alignment in the footer. The duplicate block was overriding the correct layout with a simpler flex-row configuration.

## Changes
- Removed the first duplicate `.wander-footer` block (lines 750-759)
- Removed orphaned `.wander-footer-logo`, `.wander-footer-links`, `.wander-footer-copy` styles that conflicted with the actual HTML structure
- Updated responsive media query to match the single-source footer CSS

## Related Issue
Closes #370
