### PR TITLE
UI/UX Bug: Signup Form Container Scrolls Instead of Staying Fixed

### DIFF
--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -472,6 +472,8 @@ const Register = () => {
           justifyContent: "center",
           alignItems: "center",
           p: 4,
+          height: "100vh",
+          overflow: "auto",
         }}
       >
         <Box sx={{ maxWidth: 480, width: "100%" }}>


### PR DESCRIPTION
## Description
The signup form container on the right side was introducing an unnecessary internal scroll. This fix constrains the form panel to the viewport height and allows it to scroll as a whole page unit instead.

## Changes
- Added `height: "100vh"` and `overflow: "auto"` to the right-side form container
- This keeps the form visually fixed within the viewport while allowing content to scroll naturally if it exceeds viewport height

## Related Issue
Closes #368
