### PR TITLE
docs: add reporting contact details to Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,11 +59,12 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement.
-All complaints will be reviewed and investigated promptly and fairly.
+reported to the community leaders responsible for enforcement at **community-support@packgo.org**.
+All complaints will be reviewed and investigated promptly and fairly within 48 hours.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
+
 
 ## Attribution
 


### PR DESCRIPTION
Closes #396 

# Summary
Updates the Code of Conduct to provide concrete support email and response timeline.

# Changes Made
- Modified `CODE_OF_CONDUCT.md` with official contact info.

# Testing
- Checked typography.

# Impact
Ensures community members have a safe reporting route.
