### PR TITLE
feat: add GitHub Stale Bot workflow to manage inactive issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Stale Issues and PRs Bot
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Handle Stale Issues and PRs
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. Remove the stale label or comment, or this will be closed in 5 days.'
+          stale-pr-message: 'This pull request is stale because it has been open for 14 days with no activity. Remove the stale label or comment, or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been inactive for 5 days since being marked stale.'
+          close-pr-message: 'This PR was closed because it has been inactive for 5 days since being marked stale.'
+          days-before-stale: 30
+          days-before-pr-stale: 14
+          days-before-close: 5


### PR DESCRIPTION
# Related Issue
Closes #400 

# Summary
Adds GitHub Stale Bot automation workflow to maintain repository cleanliness and manage backlog.

# Changes Made
- Created `.github/workflows/stale.yml`

# Testing
- Validated actions configuration syntax.

# Impact
Automates stale issue/PR categorization and closing.
