### PR TITLE
accessibility: add ARIA roles and labels to NotFound page

### DIFF
--- a/client/src/pages/NotFound.js
+++ b/client/src/pages/NotFound.js
@@ -61,6 +61,7 @@ const NotFound = () => {
           </Typography>
 
           <SentimentDissatisfiedIcon
+            aria-hidden="true"
             sx={{ fontSize: 60, color: "text.secondary", mb: 2 }}
           />
 
@@ -90,6 +91,8 @@ const NotFound = () => {
           </Typography>
 
           <Box
+            role="navigation"
+            aria-label="Not Found actions"
             sx={{
               display: "flex",
               justifyContent: "center",
@@ -103,6 +106,7 @@ const NotFound = () => {
               variant="contained"
               size="large"
               startIcon={<HomeIcon />}
+              aria-label="Back to home page"
               sx={{
                 borderRadius: 2,
                 px: 4,
@@ -117,6 +121,7 @@ const NotFound = () => {
               to="/contact"
               variant="outlined"
               size="large"
+              aria-label="Contact customer support"
               sx={{
                 borderRadius: 2,
                 px: 4,


### PR DESCRIPTION
# Related Issue
Closes #406 

# Summary
Improves accessibility of NotFound page using ARIA landmark roles and descriptive labels.

# Changes Made
- Modified `client/src/pages/NotFound.js`
- Added `aria-hidden="true"` to the icon
- Wrapped links inside a navigation role block with proper labels

# Testing
- Verified layout rendering.

# Impact
Provides an accessible user flow for assistive technologies.
