### PR TITLE
feat: add automatic PR folder-based labeling workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,43 @@
+name: Labeler Bot
+
+on:
+  pull_request:
+    types: [opened, synchronized]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Auto Label Pull Request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const labels = new Set();
+            for (const file of files) {
+              if (file.filename.startsWith('client/')) {
+                labels.add('frontend');
+              } else if (file.filename.startsWith('server/')) {
+                labels.add('backend');
+              } else if (file.filename.endsWith('.md') || file.filename.startsWith('.github/')) {
+                labels.add('documentation');
+              }
+            }
+
+            if (labels.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: Array.from(labels),
+              });
+            }


### PR DESCRIPTION
# Related Issue
Closes #420 

# Summary
Adds folder-based auto-labeling workflow to simplify PR classification.

# Changes Made
- Created `.github/workflows/labeler.yml`

# Testing
- Inspected code syntax.

# Impact
Auto-labels contributions by package/module type instantly.
