### PR TITLE
Fix: Remove duplicate 'Audit' word in Security Scan badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 [![MongoDB](https://img.shields.io/badge/MongoDB-Atlas-47A248?style=for-the-badge&logo=mongodb&logoColor=white)](https://www.mongodb.com/cloud/atlas)
 [![Material UI](https://img.shields.io/badge/MUI-v6-007FFF?style=for-the-badge&logo=mui&logoColor=white)](https://mui.com/)
 [![CI Pipeline](https://img.shields.io/github/actions/workflow/status/DebasmitaBose0/Travel-Plans-/ci.yml?branch=main&style=for-the-badge&label=Build%20Check)](https://github.com/DebasmitaBose0/Travel-Plans-/actions)
-[![Security Scan](https://img.shields.io/badge/Security-Audit--Audit-brightgreen?style=for-the-badge&logo=github-actions)](https://github.com/DebasmitaBose0/Travel-Plans-/actions)
+<!-- Fix: Removed duplicate 'Audit' word in Security Scan badge -->
+[![Security Scan](https://img.shields.io/badge/Security-Audit-brightgreen?style=for-the-badge&logo=github-actions)](https://github.com/DebasmitaBose0/Travel-Plans-/actions)
 
 <br />
 


### PR DESCRIPTION
## 📌 Linked Issue
- [ ] Connected to #

## 🛠 Changes Made
- Fixed: Removed duplicate 'Audit' word in Security Scan badge
  in README.md. The badge URL had 'Audit--Audit' which was 
  displaying incorrectly. Corrected to just 'Audit'.

## 🧪 Testing
- [x] Tested manually:
  - Test case 1: Open README.md on GitHub and verify 
    Security Scan badge displays correctly without 
    duplicate text

## 📸 UI Changes (if applicable)
| Before | After |
|--------|-------|
| Badge shows "Security Audit-Audit" | Badge shows "Security Audit" |

## 📝 Documentation Updates
- [x] Updated README

## ✅ Checklist
- [x] Created a new branch for PR
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes
Documentation-only change. No code logic affected.