### PR TITLE
Fix Hero Section Label Overlapping with Header (#431)

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -20,7 +20,6 @@
   font-family: "DM Sans", sans-serif;
   background: var(--white);
   color: var(--dark);
-  overflow-x: hidden;
 }
 
 html {
@@ -36,7 +35,7 @@ html {
   background: rgba(253, 250, 245, 0.92);
   backdrop-filter: blur(8px);
   border-bottom: 0.5px solid rgba(26, 74, 107, 0.12);
-  position: fixed;
+  position: sticky;
   width: 100%;
   left: 0;
   top: 0;


### PR DESCRIPTION

## 📝 Description
This PR resolves the issue where the **"2,400+ destinations worldwide"** label in the Hero section was overlapping with the sticky navigation header upon scrolling.

I have adjusted the .`position: fixed` to 'position: sticky`.

## 🔗 Related Issue
Closes #431

## 🛠️ Changes Made
- Ensured the sticky header (`sticky top-0`) does not visually conflict with underlying content.
- Verified responsiveness on mobile, tablet, and desktop views.

## 📸 Screenshots

### ❌ Before
*(Label has no proper its under the header)*
> 
<img width="1908" height="862" alt="Screenshot 2026-05-28 231158" src="https://github.com/user-attachments/assets/009e825c-3718-405b-8759-d9278ce0da7b" />


### ✅ After
*(Label has proper place and header become sticky functionality)*
> 
<img width="1909" height="900" alt="Screenshot 2026-05-30 081308" src="https://github.com/user-attachments/assets/e353b384-5aaa-4b7d-af2c-07798877e3f7" />


## ✅ Checklist
- [x] I have tested the changes locally.
- [x] The sticky header works as expected without overlap.
- [x] No other UI elements are broken by this change.
- [x] The code follows the project's style guidelines.

## 🧪 How to Test
1. Checkout this branch:  
   ```bash
   git checkout feature/sticky-header-fix