### PR TITLE
fix: resolve hero badge and navbar overlap on desktop and mobile (#436)

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -122,7 +122,8 @@ html {
   display: grid;
   grid-template-columns: 1fr 1fr;
   align-items: center;
-  padding: 4rem 3rem 4rem 4rem;
+  /* Increased top padding so hero clears the fixed navbar */
+  padding: 8rem 3rem 4rem 4rem;
   gap: 3rem;
   position: relative;
   overflow: hidden;
@@ -921,7 +922,8 @@ html {
 @media (max-width: 900px) {
   .wander-hero {
     grid-template-columns: 1fr;
-    padding: 3rem 1.5rem;
+    /* Mobile: increase top padding to clear mobile navbar */
+    padding: 7rem 1.5rem 3rem 1.5rem;
     min-height: auto;
   }
 


### PR DESCRIPTION
## Description
This PR resolves the UI bug where the hero section badge ("2,400+ destinations worldwide") and heading were colliding with and clipping behind the fixed navigation bar. 

**Fixes:** #436

## Changes Made
* **`client/src/pages/Home.css`**: Increased the `padding-top` on the `.wander-hero` container from `4rem` to `8rem` to account for the fixed navbar height on desktop.
* Updated the `@media (max-width: 900px)` mobile breakpoint to use `padding-top: 7rem` instead of a uniform `3rem` padding, ensuring the mobile navbar no longer obstructs the hero content.

## Visuals
| Before 
| :---: | :---: |
| 
<img width="1024" height="428" alt="image" src="https://github.com/user-attachments/assets/95ca6936-1513-4a7d-8c62-24ac2dc23e97" /> 
<img width="478" height="600" alt="image" src="https://github.com/user-attachments/assets/f8f8309d-f576-43d4-8740-b28d8eb6a607" />

| After
<img width="256" height="516" alt="Screenshot 2026-05-30 at 11 00 51 AM" src="https://github.com/user-attachments/assets/5f111a41-e37c-4ad1-a5d9-edb28179007e" />
<img width="1280" height="599" alt="Screenshot 2026-05-30 at 11 01 06 AM" src="https://github.com/user-attachments/assets/b3c74c30-b861-46bb-ab1b-bfb234b143ff" />
 |
| *Content clipping under the navbar* | *Content cleanly pushed below the navbar* |

## Checklist
- [x] Tested on desktop view.
- [x] Tested on mobile/responsive view.
- [x] Fix applied without breaking surrounding layouts.
- [x] Contributing Guidelines followed for GSSoC '26.