### PR TITLE
fix: resolve mobile menu layout shift and icon transition glitch (#437)

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -122,7 +122,8 @@ html {
   display: grid;
   grid-template-columns: 1fr 1fr;
   align-items: center;
-  padding: 4rem 3rem 4rem 4rem;
+  /* Increased top padding so hero clears the fixed navbar */
+  padding: 8rem 3rem 4rem 4rem;
   gap: 3rem;
   position: relative;
   overflow: hidden;
@@ -921,7 +922,8 @@ html {
 @media (max-width: 900px) {
   .wander-hero {
     grid-template-columns: 1fr;
-    padding: 3rem 1.5rem;
+    /* Mobile: increase top padding to clear mobile navbar */
+    padding: 7rem 1.5rem 3rem 1.5rem;
     min-height: auto;
   }
 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -471,6 +471,7 @@ const Home = () => {
         >
           {mobileOpen ? (
             <svg
+              key="close-icon"
               width="24"
               height="24"
               viewBox="0 0 24 24"
@@ -482,6 +483,7 @@ const Home = () => {
             </svg>
           ) : (
             <svg
+              key="menu-icon"
               width="24"
               height="24"
               viewBox="0 0 24 24"
@@ -495,65 +497,48 @@ const Home = () => {
             </svg>
           )}
         </button>
-      </nav>
-
-      {/* Mobile dropdown */}
-      {mobileOpen && (
-        <div
-          style={{
-            background: "var(--white)",
-            borderBottom: "0.5px solid rgba(26,74,107,0.12)",
-            padding: "1rem 1.5rem",
-            display: "flex",
-            flexDirection: "column",
-            gap: "1rem",
-          }}
-        >
-          <a
-            href="#wander-dest-section"
+        {mobileOpen && (
+          <div
             style={{
-              color: "var(--ocean)",
-              textDecoration: "none",
-              fontWeight: 500,
+              position: "absolute",
+              top: "100%",
+              left: 0,
+              right: 0,
+              background: "var(--white)",
+              borderBottom: "0.5px solid rgba(26,74,107,0.12)",
+              boxShadow: "0 16px 32px rgba(15, 45, 64, 0.14)",
+              padding: "1rem 1.5rem",
+              display: "flex",
+              flexDirection: "column",
+              gap: "1rem",
+              zIndex: 1001,
             }}
-            onClick={() => setMobileOpen(false)}
           >
-            Destinations
-          </a>
-          <a
-            href="#wander-features"
-            style={{
-              color: "var(--ocean)",
-              textDecoration: "none",
-              fontWeight: 500,
-            }}
-            onClick={() => setMobileOpen(false)}
-          >
-            Features
-          </a>
-          {isAuthenticated ? (
-            <Link
-              to="/dashboard"
+            <a
+              href="#wander-dest-section"
               style={{
-                color: "var(--coral)",
-                fontWeight: 600,
+                color: "var(--ocean)",
                 textDecoration: "none",
+                fontWeight: 500,
               }}
               onClick={() => setMobileOpen(false)}
             >
-              Dashboard →
-            </Link>
-          ) : (
-            <>
+              Destinations
+            </a>
+            <a
+              href="#wander-features"
+              style={{
+                color: "var(--ocean)",
+                textDecoration: "none",
+                fontWeight: 500,
+              }}
+              onClick={() => setMobileOpen(false)}
+            >
+              Features
+            </a>
+            {isAuthenticated ? (
               <Link
-                to="/login"
-                style={{ color: "var(--ocean)", textDecoration: "none" }}
-                onClick={() => setMobileOpen(false)}
-              >
-                Log In
-              </Link>
-              <Link
-                to="/register"
+                to="/dashboard"
                 style={{
                   color: "var(--coral)",
                   fontWeight: 600,
@@ -561,12 +546,33 @@ const Home = () => {
                 }}
                 onClick={() => setMobileOpen(false)}
               >
-                Sign Up Free →
+                Dashboard →
               </Link>
-            </>
-          )}
-        </div>
-      )}
+            ) : (
+              <>
+                <Link
+                  to="/login"
+                  style={{ color: "var(--ocean)", textDecoration: "none" }}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Log In
+                </Link>
+                <Link
+                  to="/register"
+                  style={{
+                    color: "var(--coral)",
+                    fontWeight: 600,
+                    textDecoration: "none",
+                  }}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Sign Up Free →
+                </Link>
+              </>
+            )}
+          </div>
+        )}
+      </nav>
 
       {/* ═══ HERO ═══ */}
       <section className="wander-hero">


### PR DESCRIPTION
## Description
This PR resolves the UX issues with the mobile navigation menu, specifically the jarring layout shift that pushes the Hero section down and the visual glitch during the icon state change[cite: 1].

**Fixes:** #437[cite: 1]

## Changes Made
* **`client/src/pages/Home.js`**: 
  * Added unique `key` props to the hamburger and close (`X`) SVG icons to force a clean React remount, eliminating the transition artifact[cite: 1].
  * Moved the mobile dropdown container inside the fixed `<nav>` wrapper.
  * Updated the dropdown's inline styles to use `position: "absolute"` and `top: "100%"`, allowing it to slide down smoothly as an overlay without pushing the document flow[cite: 1].
  * Added a `box-shadow` to give the overlay depth against the hero section.

## Visuals
| Before |

https://github.com/user-attachments/assets/5372bc50-f8a4-482b-a2a4-57cf70a56be2

after 

https://github.com/user-attachments/assets/32fd4f59-d240-4b94-b837-1425c73ae21e


## Checklist
- [x] Tested mobile menu toggle overlay behavior[cite: 1].
- [x] Verified clean SVG icon transitions[cite: 1].
- [x] Verified no layout shift occurs on the page below[cite: 1].
- [x] Contributing Guidelines followed for GSSoC '26[cite: 1].