### PR TITLE
Replace old Twitter logo with X logo on login page.

### DIFF
--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -19,8 +19,8 @@ import {
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import FacebookIcon from "@mui/icons-material/Facebook";
-import TwitterIcon from "@mui/icons-material/Twitter";
 import LoginIcon from "@mui/icons-material/Login";
+import { FaXTwitter } from "react-icons/fa6";
 import PrimaryButton from "../components/PrimaryButton";
 
 const Login = () => {
@@ -390,16 +390,17 @@ const Login = () => {
                   </IconButton>
                   <IconButton
                     disabled
+                    aria-label="Sign in with X"
                     sx={{
                       border: "1px solid",
                       borderColor: "divider",
                       borderRadius: 2,
                       p: 1.5,
-                      color: "#1DA1F2",
+                      color: "text.primary",
                       opacity: 0.5,
                     }}
                   >
-                    <TwitterIcon />
+                    <FaXTwitter />
                   </IconButton>
                 </Box>
               </Box>


### PR DESCRIPTION
Replace outdated Twitter bird icon with the current X logo on the login page social sign-in button.

---
name: "📦 Pull Request"
about: Submit changes for review
title: "PR: [Replace old Twitter logo with X logo on login page]"
assignees: "honey-pg"
---

## 📌 Linked Issue

Closes #229 

---

## 🛠 Changes Made

- Fixed: Replaced outdated Twitter bird icon with the current X logo on the login page social sign-in button
- Updated: Switched from `@mui/icons-material/Twitter` to `FaXTwitter` from `react-icons/fa6`
- Updated: Icon color and `aria-label` to match X branding (`Sign in with X`)

---

## 🧪 Testing

- [x] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Navigate to `/login` → social sign-in section shows the X logo instead of the old Twitter bird
  - Test case 2: Verify icon styling matches other social buttons and remains disabled (placeholder state)

---

