### PR TITLE
fix: add Terms of Service and Privacy Policy pages

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,6 +20,8 @@ import ResetPassword from "./pages/ResetPassword";
 import NotFound from "./pages/NotFound";
 import PrivateRoute from "./components/PrivateRoute";
 import { loadUser } from "./redux/actions/authActions";
+import TermsOfService from "./pages/TermsOfService";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
 
 function App() {
   useEffect(() => {
@@ -48,6 +50,8 @@ function App() {
               <Route path="/forgot-password" element={<ForgotPassword />} />
               <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/shared-trip/:token" element={<SharedTripView />} />
+              <Route path="/terms" element={<TermsOfService />} />
+              <Route path="/privacy" element={<PrivacyPolicy />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </div>

--- a/client/src/pages/PrivacyPolicy.js
+++ b/client/src/pages/PrivacyPolicy.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+function PrivacyPolicy() {
+  return (
+    <div style={{ padding: "40px" }}>
+      <h1>Privacy Policy</h1>
+      <p>
+        We respect your privacy and are committed to protecting your personal
+        information.
+      </p>
+    </div>
+  );
+}
+
+export default PrivacyPolicy;

--- a/client/src/pages/TermsOfService.js
+++ b/client/src/pages/TermsOfService.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+function TermsOfService() {
+  return (
+    <div style={{ padding: "40px" }}>
+      <h1>Terms of Service</h1>
+      <p>
+        Welcome to Travel Plans. By using this platform, you agree to comply
+        with our terms and conditions.
+      </p>
+    </div>
+  );
+}
+
+export default TermsOfService;


### PR DESCRIPTION
## Description

This PR fixes issue #112 by adding dedicated Terms of Service and Privacy Policy pages and configuring routes for both pages.

## Changes Made

* Added Terms of Service page
* Added Privacy Policy page
* Added `/terms` route
* Added `/privacy` route
* Verified navigation from the registration page

## Issue Fixed

Closes #112