### PR TITLE
fix: README setup instructions and empty-state dashboard notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Make sure you have the following installed:
 
 ```bash
 git clone https://github.com/hitesh-kumar123/Travel-Plans-.git
-cd travel-planner
+cd Travel-Plans-
 ```
 
 ### 2. Install Dependencies
@@ -591,21 +591,23 @@ We are incredibly grateful to our mentors for their valuable support and code re
 
 ---
 
-
 ⭐ **If PackGo helped you, please give it a star — it means a lot!** ⭐
 
 </div>
 
-/**
+/\*\*
+
 ## ✨ README Improvement Notes
 
 ### 📌 Formatting Enhancements Needed
+
 - Improve heading hierarchy for better readability
 - Ensure consistent spacing between sections
 - Use proper Markdown formatting for code blocks and lists
 - Align all installation and usage steps properly
 
 ### 🚀 Suggested Structure Upgrade
+
 - Introduction
 - Features
 - Tech Stack
@@ -616,10 +618,12 @@ We are incredibly grateful to our mentors for their valuable support and code re
 - License
 
 ### 🛠️ Documentation Improvements
+
 - Add badges (optional): build, license, contributors
 - Add screenshots for better UI understanding
 - Standardize code blocks for commands
 
 ### 🎯 Goal
+
 Improve onboarding experience for new contributors and users by making README more structured, readable, and professional.
-*/
+\*/

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -66,33 +66,7 @@ const Dashboard = () => {
   const dispatch = useDispatch();
   const { user } = useSelector((state) => state.auth);
 
-  const notifications = [
-    {
-      id: 1,
-      title: "Trip created successfully",
-      time: "2 min ago",
-    },
-    {
-      id: 2,
-      title: "Weather forecast updated",
-      time: "10 min ago",
-    },
-    {
-      id: 3,
-      title: "Budget exceeded for Goa trip",
-      time: "1 hour ago",
-    },
-    {
-      id: 4,
-      title: "New destination suggestions available",
-      time: "Today",
-    },
-    {
-      id: 5,
-      title: "Manali trip completed",
-      time: "Yesterday",
-    },
-  ];
+  const [notifications, setNotifications] = useState([]);
 
   const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
   const handleMenu = (event) => setAnchorEl(event.currentTarget);
@@ -437,39 +411,47 @@ const Dashboard = () => {
                     overflowY: "auto",
                   }}
                 >
-                  {notifications.map((notification) => (
-                    <MenuItem
-                      key={notification.id}
-                      onClick={handleNotificationClose}
-                      sx={{
-                        py: 1.5,
-                        alignItems: "flex-start",
-                        borderBottom: "1px solid",
-                        borderColor: "grey.100",
-                      }}
-                    >
-                      <Box>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            fontWeight: 600,
-                            color: "text.primary",
-                          }}
-                        >
-                          {notification.title}
-                        </Typography>
+                  {notifications.length > 0 ? (
+                    notifications.map((notification) => (
+                      <MenuItem
+                        key={notification.id}
+                        onClick={handleNotificationClose}
+                        sx={{
+                          py: 1.5,
+                          alignItems: "flex-start",
+                          borderBottom: "1px solid",
+                          borderColor: "grey.100",
+                        }}
+                      >
+                        <Box>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontWeight: 600,
+                              color: "text.primary",
+                            }}
+                          >
+                            {notification.title}
+                          </Typography>
 
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            color: "text.secondary",
-                          }}
-                        >
-                          {notification.time}
-                        </Typography>
-                      </Box>
-                    </MenuItem>
-                  ))}
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              color: "text.secondary",
+                            }}
+                          >
+                            {notification.time}
+                          </Typography>
+                        </Box>
+                      </MenuItem>
+                    ))
+                  ) : (
+                    <Box sx={{ p: 3, textAlign: "center" }}>
+                      <Typography variant="body2" color="text.secondary">
+                        No new notifications
+                      </Typography>
+                    </Box>
+                  )}
                 </Box>
               </Menu>
             </Box>


### PR DESCRIPTION
## Description
This PR resolves two open issues in the project:
1. **Fix incorrect directory name in README cloning instructions (resolves #477)**:
   - Changes `cd travel-planner` to `cd Travel-Plans-` inside the `README.md` to prevent "path not found" errors when cloning and setting up the project.
2. **Fix hardcoded notifications count in dashboard sidebar (resolves #492)**:
   - Converts the hardcoded static `notifications` array in `client/src/pages/Dashboard.js` into a React state variable initialized to `[]`.
   - Handles the empty-state UI gracefully by displaying a "No new notifications" message inside the dropdown menu instead of showing an empty box or a static badge value.

## Tests and Verification
- Ran prettier formatting to comply with the project standards.