### PR TITLE
UI Bug: Improve mobile layout of trip/booking cards (#444)

### DIFF
--- a/client/src/pages/dashboard/BookingView.js
+++ b/client/src/pages/dashboard/BookingView.js
@@ -434,7 +434,7 @@ const BookingView = () => {
           <Typography variant="h6" fontWeight={700} mb={2}>
             {hotels.length} Hotels Found
           </Typography>
-          <Grid container spacing={3}>
+          <Grid container spacing={{ xs: 2, md: 3 }}>
             {hotels.map((hotel) => (
               <Grid xs={12} md={6} lg={4} key={hotel.id}>
                 <Card
@@ -461,8 +461,8 @@ const BookingView = () => {
                       sx={{ fontSize: 64, color: "primary.main", opacity: 0.4 }}
                     />
                   </Box>
-                  <CardContent>
-                    <Typography variant="h6" fontWeight={700}>
+                  <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
+                    <Typography variant="h6" fontWeight={700} sx={{ wordBreak: "break-word" }}>
                       {hotel.name}
                     </Typography>
                     <Typography variant="body2" color="text.secondary" mb={1}>
@@ -510,6 +510,8 @@ const BookingView = () => {
                         display: "flex",
                         justifyContent: "space-between",
                         alignItems: "center",
+                        flexWrap: "wrap",
+                        gap: 1,
                       }}
                     >
                       <Box>

--- a/client/src/pages/dashboard/BookingView.js
+++ b/client/src/pages/dashboard/BookingView.js
@@ -462,7 +462,11 @@ const BookingView = () => {
                     />
                   </Box>
                   <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-                    <Typography variant="h6" fontWeight={700} sx={{ wordBreak: "break-word" }}>
+                    <Typography
+                      variant="h6"
+                      fontWeight={700}
+                      sx={{ wordBreak: "break-word" }}
+                    >
                       {hotel.name}
                     </Typography>
                     <Typography variant="body2" color="text.secondary" mb={1}>

--- a/client/src/pages/dashboard/TripsView.js
+++ b/client/src/pages/dashboard/TripsView.js
@@ -264,7 +264,7 @@ const TripsView = () => {
       </Dialog>
 
       {/* Trips Grid */}
-      <Grid container spacing={3}>
+      <Grid container spacing={{ xs: 2, md: 3 }}>
         {loading ? (
           Array.from({ length: 3 }).map((_, i) => (
             <Grid xs={12} md={6} lg={4} key={i}>
@@ -326,8 +326,8 @@ const TripsView = () => {
                         />
                       </Box>
                     </Box>
-                    <CardContent sx={{ pb: "12px !important" }}>
-                      <Typography variant="h6" fontWeight={700} gutterBottom>
+                    <CardContent sx={{ pb: "12px !important", p: { xs: 2, sm: 3 } }}>
+                      <Typography variant="h6" fontWeight={700} gutterBottom sx={{ wordBreak: "break-word" }}>
                         {trip.destination}
                       </Typography>
                       <Box
@@ -336,6 +336,7 @@ const TripsView = () => {
                           alignItems: "center",
                           gap: 0.5,
                           mb: 1,
+                          flexWrap: "wrap",
                         }}
                       >
                         <DateRangeIcon fontSize="small" color="action" />
@@ -359,6 +360,7 @@ const TripsView = () => {
                             display: "flex",
                             alignItems: "center",
                             gap: 0.5,
+                            flexWrap: "wrap",
                           }}
                         >
                           <WalletIcon fontSize="small" color="success" />

--- a/client/src/pages/dashboard/TripsView.js
+++ b/client/src/pages/dashboard/TripsView.js
@@ -326,8 +326,15 @@ const TripsView = () => {
                         />
                       </Box>
                     </Box>
-                    <CardContent sx={{ pb: "12px !important", p: { xs: 2, sm: 3 } }}>
-                      <Typography variant="h6" fontWeight={700} gutterBottom sx={{ wordBreak: "break-word" }}>
+                    <CardContent
+                      sx={{ pb: "12px !important", p: { xs: 2, sm: 3 } }}
+                    >
+                      <Typography
+                        variant="h6"
+                        fontWeight={700}
+                        gutterBottom
+                        sx={{ wordBreak: "break-word" }}
+                      >
                         {trip.destination}
                       </Typography>
                       <Box


### PR DESCRIPTION
### Description
This PR improves the responsiveness and visual consistency of the card-based UI sections in the dashboard on smaller screens. 

**Changes applied:**
- Adjusted grid spacing to respond dynamically (e.g., using `spacing={{ xs: 2, md: 3 }}`).
- Added consistent mobile padding to `CardContent` within `TripsView.js` and `BookingView.js`.
- Implemented `flexWrap: "wrap"` to ensure cleaner stacked layouts for inline items (like dates and budget elements).
- Forced word-breaking on long titles to prevent overflow on extra-narrow devices.

Fixes #444.



### Mobile Layout Improvements (Before & After)
| Before | After |
|--------|-------|
| <img src="https://raw.githubusercontent.com/bhavyapandiya29/Travel-Plans-/add-pr-images/docs/assets/before.png" width="300" /> | <img src="https://raw.githubusercontent.com/bhavyapandiya29/Travel-Plans-/add-pr-images/docs/assets/after.png" width="300" /> |
