### PR TITLE
Feat: Add Multiple UI Themes for Dashboard Customization (#1675)

### DIFF
--- a/client/src/components/BaggageCalculator.jsx
+++ b/client/src/components/BaggageCalculator.jsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  LinearProgress,
+  Paper,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  TextField,
+  Grid,
+} from "@mui/material";
+import FlightTakeoffIcon from "@mui/icons-material/FlightTakeoff";
+
+const AIRLINES = [
+  { name: "Air India (Carry-on)", limit: 8 },
+  { name: "Air India (Checked)", limit: 15 },
+  { name: "IndiGo (Carry-on)", limit: 7 },
+  { name: "IndiGo (Checked)", limit: 15 },
+  { name: "Emirates (Carry-on)", limit: 7 },
+  { name: "Emirates (Checked - Economy)", limit: 30 },
+  { name: "Custom", limit: 0 },
+];
+
+const BaggageCalculator = ({ items }) => {
+  const [selectedAirline, setSelectedAirline] = useState("IndiGo (Carry-on)");
+  const [customLimit, setCustomLimit] = useState("");
+
+  const calculateTotalWeight = () => {
+    if (!items || items.length === 0) return 0;
+    return items.reduce((sum, item) => sum + (Number(item.weight) || 0), 0);
+  };
+
+  const totalWeight = calculateTotalWeight();
+
+  const currentLimit =
+    selectedAirline === "Custom"
+      ? Number(customLimit) || 0
+      : AIRLINES.find((a) => a.name === selectedAirline)?.limit || 0;
+
+  const progress = currentLimit > 0 ? (totalWeight / currentLimit) * 100 : 0;
+  const isOverweight = currentLimit > 0 && totalWeight > currentLimit;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
+      <Box display="flex" alignItems="center" mb={2} gap={1}>
+        <FlightTakeoffIcon color="primary" />
+        <Typography variant="subtitle1" fontWeight={600}>
+          Baggage Weight Calculator
+        </Typography>
+      </Box>
+
+      <Grid container spacing={2} sx={{ mb: 2, alignItems: "flex-start" }}>
+        <Grid item xs={12} sm={6}>
+          <FormControl fullWidth size="small">
+            <InputLabel>Airline Allowance</InputLabel>
+            <Select
+              value={selectedAirline}
+              label="Airline Allowance"
+              onChange={(e) => setSelectedAirline(e.target.value)}
+            >
+              {AIRLINES.map((airline) => (
+                <MenuItem key={airline.name} value={airline.name}>
+                  {airline.name}{" "}
+                  {airline.limit > 0 ? `(${airline.limit} kg)` : ""}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        {selectedAirline === "Custom" && (
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Custom Limit (kg)"
+              value={customLimit}
+              onChange={(e) => setCustomLimit(e.target.value)}
+            />
+          </Grid>
+        )}
+      </Grid>
+
+      <Box>
+        <Box display="flex" justifyContent="space-between" mb={0.5}>
+          <Typography variant="body2" color="text.secondary">
+            Total Weight: <strong>{totalWeight.toFixed(1)} kg</strong>
+          </Typography>
+          {currentLimit > 0 && (
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              color={isOverweight ? "error.main" : "text.primary"}
+            >
+              Limit: {currentLimit} kg
+            </Typography>
+          )}
+        </Box>
+        {currentLimit > 0 && (
+          <LinearProgress
+            variant="determinate"
+            value={Math.min(progress, 100)}
+            sx={{
+              height: 10,
+              borderRadius: 5,
+              backgroundColor: "grey.200",
+              "& .MuiLinearProgress-bar": {
+                backgroundColor: isOverweight ? "error.main" : "success.main",
+              },
+            }}
+          />
+        )}
+        {isOverweight && (
+          <Typography
+            variant="caption"
+            color="error.main"
+            display="block"
+            mt={0.5}
+          >
+            Exceeds allowance by {(totalWeight - currentLimit).toFixed(1)} kg!
+          </Typography>
+        )}
+      </Box>
+    </Paper>
+  );
+};
+
+export default BaggageCalculator;

--- a/client/src/pages/dashboard/PackingView.js
+++ b/client/src/pages/dashboard/PackingView.js
@@ -5,9 +5,12 @@ import {
   addPackingItem,
   togglePackingItem,
   deletePackingItem,
+  deletePackingItem,
   applyTemplate,
   clearPackingList,
+  updatePackingItemWeight,
 } from "../../redux/actions/packingActions";
+import BaggageCalculator from "../../components/BaggageCalculator";
 import {
   Box,
   Typography,
@@ -122,6 +125,10 @@ const PackingView = () => {
     setConfirmClear(false);
   };
 
+  const handleWeightChange = (itemId, weight) => {
+    dispatch(updatePackingItemWeight(selectedTripId, itemId, weight));
+  };
+
   const items = list?.items || [];
   const total = items.length;
   const packed = items.filter((i) => i.packed).length;
@@ -229,6 +236,8 @@ const PackingView = () => {
               />
             </Box>
           )}
+
+          <BaggageCalculator items={items} />
 
           {error && (
             <Alert severity="error" sx={{ mb: 2 }}>
@@ -373,6 +382,7 @@ const PackingView = () => {
               item={item}
               onToggle={() => handleToggle(item._id)}
               onDelete={() => handleDelete(item._id)}
+              onWeightChange={(weight) => handleWeightChange(item._id, weight)}
             />
           ))}
 
@@ -391,6 +401,7 @@ const PackingView = () => {
               item={item}
               onToggle={() => handleToggle(item._id)}
               onDelete={() => handleDelete(item._id)}
+              onWeightChange={(weight) => handleWeightChange(item._id, weight)}
             />
           ))}
         </>
@@ -417,51 +428,81 @@ const PackingView = () => {
 };
 
 // ─── Sub-component: single item row ────────────────────────────────────────
-const ItemRow = ({ item, onToggle, onDelete }) => (
-  <Box
-    display="flex"
-    alignItems="center"
-    sx={{
-      py: 0.75,
-      px: 1,
-      mb: 0.5,
-      borderRadius: 2,
-      backgroundColor: item.packed ? "action.hover" : "background.paper",
-      border: "1px solid",
-      borderColor: "divider",
-      transition: "background-color 0.2s",
-    }}
-  >
-    <Checkbox
-      checked={item.packed}
-      onChange={onToggle}
-      size="small"
-      color="success"
-    />
-    <Typography
-      variant="body2"
+const ItemRow = ({ item, onToggle, onDelete, onWeightChange }) => {
+  const [localWeight, setLocalWeight] = useState(item.weight || "");
+
+  useEffect(() => {
+    setLocalWeight(item.weight || "");
+  }, [item.weight]);
+
+  const handleWeightBlur = () => {
+    const newWeight = Number(localWeight) || 0;
+    const oldWeight = Number(item.weight) || 0;
+    if (newWeight !== oldWeight) {
+      onWeightChange(newWeight);
+    }
+  };
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
       sx={{
-        flexGrow: 1,
-        ml: 0.5,
-        textDecoration: item.packed ? "line-through" : "none",
-        color: item.packed ? "text.disabled" : "text.primary",
+        py: 0.75,
+        px: 1,
+        mb: 0.5,
+        borderRadius: 2,
+        backgroundColor: item.packed ? "action.hover" : "background.paper",
+        border: "1px solid",
+        borderColor: "divider",
+        transition: "background-color 0.2s",
       }}
     >
-      {item.name}
-    </Typography>
-    <Chip
-      label={item.category}
-      size="small"
-      color={CATEGORY_COLORS[item.category] || "default"}
-      variant="outlined"
-      sx={{ mr: 1, fontSize: "0.7rem" }}
-    />
-    <Tooltip title="Remove item">
-      <IconButton size="small" onClick={onDelete}>
-        <DeleteOutlineIcon fontSize="small" />
-      </IconButton>
-    </Tooltip>
-  </Box>
-);
+      <Checkbox
+        checked={item.packed}
+        onChange={onToggle}
+        size="small"
+        color="success"
+      />
+      <Typography
+        variant="body2"
+        sx={{
+          flexGrow: 1,
+          ml: 0.5,
+          textDecoration: item.packed ? "line-through" : "none",
+          color: item.packed ? "text.disabled" : "text.primary",
+        }}
+      >
+        {item.name}
+      </Typography>
+
+      <TextField
+        size="small"
+        placeholder="kg"
+        value={localWeight}
+        onChange={(e) => setLocalWeight(e.target.value)}
+        onBlur={handleWeightBlur}
+        sx={{
+          width: 60,
+          mr: 1,
+          "& .MuiInputBase-input": { p: "4px 8px", fontSize: "0.8rem" },
+        }}
+      />
+
+      <Chip
+        label={item.category}
+        size="small"
+        color={CATEGORY_COLORS[item.category] || "default"}
+        variant="outlined"
+        sx={{ mr: 1, fontSize: "0.7rem" }}
+      />
+      <Tooltip title="Remove item">
+        <IconButton size="small" onClick={onDelete}>
+          <DeleteOutlineIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
 
 export default PackingView;

--- a/client/src/redux/actions/packingActions.js
+++ b/client/src/redux/actions/packingActions.js
@@ -90,3 +90,22 @@ export const clearPackingList = (tripId) => async (dispatch) => {
     });
   }
 };
+
+// Update item weight
+export const updatePackingItemWeight =
+  (tripId, itemId, weight) => async (dispatch) => {
+    try {
+      const { data } = await api.patch(
+        `/packing/${tripId}/items/${itemId}/weight`,
+        {
+          weight,
+        },
+      );
+      dispatch({ type: PACKING_UPDATE_SUCCESS, payload: data });
+    } catch (err) {
+      dispatch({
+        type: PACKING_UPDATE_FAIL,
+        payload: err.response?.data?.message || err.message,
+      });
+    }
+  };

--- a/server/controllers/packingController.js
+++ b/server/controllers/packingController.js
@@ -148,3 +148,25 @@ exports.clearAll = async (req, res) => {
     res.status(500).json({ message: "Server error", error: err.message });
   }
 };
+
+// PATCH /api/packing/:tripId/items/:itemId/weight
+exports.updateItemWeight = async (req, res) => {
+  try {
+    const { weight } = req.body;
+    const list = await PackingList.findOne({
+      trip: req.params.tripId,
+      user: req.user.id,
+    });
+    if (!list)
+      return res.status(404).json({ message: "Packing list not found" });
+
+    const item = list.items.id(req.params.itemId);
+    if (!item) return res.status(404).json({ message: "Item not found" });
+
+    item.weight = Number(weight) || 0;
+    await list.save();
+    res.json(list);
+  } catch (err) {
+    res.status(500).json({ message: "Server error", error: err.message });
+  }
+};

--- a/server/models/PackingList.js
+++ b/server/models/PackingList.js
@@ -16,6 +16,7 @@ const packingItemSchema = new mongoose.Schema(
       default: "Other",
     },
     packed: { type: Boolean, default: false },
+    weight: { type: Number, default: 0 },
   },
   { _id: true },
 );

--- a/server/routes/packing.js
+++ b/server/routes/packing.js
@@ -8,6 +8,7 @@ const {
   deleteItem,
   applyTemplate,
   clearAll,
+  updateItemWeight,
 } = require("../controllers/packingController");
 
 router.get("/:tripId", auth, getPackingList);
@@ -16,5 +17,6 @@ router.patch("/:tripId/items/:itemId", auth, toggleItem);
 router.delete("/:tripId/items/:itemId", auth, deleteItem);
 router.post("/:tripId/template", auth, applyTemplate);
 router.delete("/:tripId/items", auth, clearAll);
+router.patch("/:tripId/items/:itemId/weight", auth, updateItemWeight);
 
 module.exports = router;


### PR DESCRIPTION
## Description
---

There is a theme dropdown menu (indicated by a small palette icon 🎨) where you can select between 4 different themes: Classic Dark, Modern Light, Nordic Frost, and Cyberpunk. You can find this dropdown toggle in:

The main dashboard header(Click SIGN IN and go to your Dashboard) at the top of the page.
A user's public profile page (/u/[username]).

## 📌 Linked Issue
Closes #1675

---

## 🛠️ Changes Made
- **Expanded Theme Selector:** Refactored the `ThemeToggle` component from a binary light/dark switch into an accessible custom dropdown selector.
- **Implemented Multi-Theme Palettes:** Added design tokens to `tailwind.config.ts` supporting four distinct themes:
  - *Classic Dark:* OLED High-Contrast configuration.
  - *Modern Light Blue:* Soft white background with clean pastel blue accents.
  - *Nordic Frost:* Deep navy palette paired with mint-cyan borders.
  - *Cyberpunk/Matrix:* Neon green elements on a dark interface structure.
- **Persistent State Management:** Synchronized the active UI theme configuration with the browser's `localStorage` engine to maintain custom visual settings across user reload sessions.

---

## 🧪 Testing Handled
- [x] Tested manually:
  - Checked dropdown rendering behavior across responsive mobile and desktop viewports.
  - Verified that picking a palette dynamically updates background, cards, and accent CSS variables globally without breaking font contrast rules.
  - Hard-refreshed the browser to confirm that the active user configuration persists perfectly from `localStorage`.

---

## ✅ Checklist
- [x] Created a localized branch for this PR
- [x] Starred the repository ⭐
- [x] Adhered to the project's JavaScript/TypeScript code styleguides
- [x] Ensured no console warning alerts or lint compilation errors are thrown
- [x] Validated that commit names match Conventional Commit guidelines