### PR TITLE
fix: resolve check-in date icon overlapping issue (#289)

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -357,10 +357,9 @@ html {
   margin-bottom: 0.3rem;
 }
 
-.wander-sf-val {
-  font-size: 0.95rem;
-  color: var(--ocean);
-  font-weight: 500;
+.wander-sf-val::-webkit-calendar-picker-indicator {
+  opacity: 0;
+  cursor: pointer;
 }
 
 .wander-sf-val.placeholder {


### PR DESCRIPTION
Title:

fix: resolve check-in date icon overlapping issue (#289)

Description:

Description:
This PR fixes a UI bug in the Booking Section where the native browser calendar icon was overlapping with the custom SVG calendar icon within the check-in date input field.

Changes Made:

Targeted the .wander-sf-val::-webkit-calendar-picker-indicator pseudo-element in Home.css.

Set opacity: 0 to hide the native browser icon while maintaining its clickable functionality.