### PR TITLE
fix: replace CRA default meta description and manifest with PackGo br…

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,39 +5,31 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+
+    <!-- Primary meta description -->
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="PackGo – Your smart travel planning companion. Plan trips, track expenses, manage packing lists, and explore destinations across India."
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <!-- Open Graph / WhatsApp / LinkedIn / Facebook previews -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="PackGo - Travel Planner" />
+    <meta property="og:description" content="PackGo – Your smart travel planning companion. Plan trips, track expenses, manage packing lists, and explore destinations across India." />
+    <meta property="og:image" content="%PUBLIC_URL%/logo512.png" />
+
+    <!-- Twitter / X card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="PackGo - Travel Planner" />
+    <meta name="twitter:description" content="PackGo – Your smart travel planning companion. Plan trips, track expenses, manage packing lists, and explore destinations across India." />
+    <meta name="twitter:image" content="%PUBLIC_URL%/logo512.png" />
+
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>PackGo - Travel Planner</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "PackGo",
+  "name": "PackGo - Travel Planner",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
---
name: "📦 Pull Request"
about: Submit changes for review
title: "PR: Fix CRA default meta description and manifest branding"
---

## 📌 Linked Issue
Closes #386

---

## 🛠 Changes Made
- Fixed: Replaced default CRA meta description with PackGo-specific content
- Added: Open Graph tags for rich link previews on WhatsApp, LinkedIn, and Facebook
- Added: Twitter card tags for rich previews on Twitter/X
- Updated: `manifest.json` short_name from "React App" to "PackGo"
- Updated: `manifest.json` name from "Create React App Sample" to "PackGo - Travel Planner"

---

## 🧪 Testing
- [ ] Ran unit tests (`npm test`)
- [x] Tested manually:
  - Test case 1: Open `client/public/index.html` in browser → View Page Source → Search "description" → confirms PackGo description is shown
  - Test case 2: Paste deployed URL into [Twitter Card Validator](https://cards-dev.twitter.com/validator) → confirms card preview renders correctly
  - Test case 3: Paste deployed URL into [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) → confirms OG tags are picked up

---

## 📸 UI Changes (if applicable)
| Before | After |
| ------- | ------- |
| `"Web site created using create-react-app"` | `"PackGo – Your smart travel planning companion..."` |
| `short_name: "React App"` | `short_name: "PackGo"` |

---

## 📝 Documentation Updates
- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist
- [x] Created a new branch for PR (`fix/seo-meta-description`)
- [ ] Have starred the repository ⭐
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes
Both files (`index.html` and `manifest.json`) had leftover CRA scaffold defaults that were never updated after project setup. Changes are non-breaking and only affect metadata visible to search engines, social platforms, and PWA installs.