### PR TITLE
Add recently searched destinations dropdown

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -348,6 +348,35 @@ html {
   border-right: 0.5px solid rgba(26, 74, 107, 0.08);
 }
 
+.wander-recent-searches {
+  position: absolute;
+  left: 1.5rem;
+  right: 1.5rem;
+  top: calc(100% + 0.5rem);
+  background: #ffffff;
+  border: 1px solid rgba(26, 74, 107, 0.12);
+  border-radius: 14px;
+  box-shadow: 0 16px 40px rgba(15, 45, 64, 0.14);
+  max-height: 220px;
+  overflow-y: auto;
+  z-index: 20;
+}
+
+.wander-recent-search-item {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0.9rem 1rem;
+  text-align: left;
+  color: var(--ocean);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.wander-recent-search-item:hover {
+  background: rgba(26, 74, 107, 0.05);
+}
+
 .wander-sf-label {
   font-size: 0.7rem;
   font-weight: 500;

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -346,6 +346,8 @@ const SearchIcon = () => (
   </svg>
 );
 
+const SEARCH_HISTORY_KEY = "recentDestinationSearches";
+
 /* ══════════════════════════════════════════════════════════════ */
 /*  COMPONENT                                                      */
 /* ══════════════════════════════════════════════════════════════ */
@@ -359,8 +361,38 @@ const Home = () => {
   const [where, setWhere] = useState("");
   const [checkIn, setCheckIn] = useState("");
   const [travellers, setTravellers] = useState("");
+  const [recentSearches, setRecentSearches] = useState([]);
+  const [showRecentSearches, setShowRecentSearches] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    try {
+      const saved = JSON.parse(
+        localStorage.getItem(SEARCH_HISTORY_KEY) ?? "[]",
+      );
+      if (Array.isArray(saved)) {
+        setRecentSearches(saved.filter((item) => typeof item === "string"));
+      }
+    } catch (error) {
+      console.error("Failed to load search history:", error);
+    }
+  }, []);
+
+  const updateSearchHistory = (query) => {
+    const normalized = query.trim();
+    if (!normalized) return;
+
+    const nextSearches = [
+      normalized,
+      ...recentSearches.filter(
+        (item) => item.toLowerCase() !== normalized.toLowerCase(),
+      ),
+    ].slice(0, 5);
+
+    setRecentSearches(nextSearches);
+    localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(nextSearches));
+  };
 
   useEffect(() => {
     api
@@ -409,6 +441,11 @@ const Home = () => {
 
   const handleSearch = (e) => {
     e.preventDefault();
+    const query = where.trim();
+    if (query) {
+      updateSearchHistory(query);
+    }
+    setShowRecentSearches(false);
     document
       .getElementById("wander-dest-section")
       ?.scrollIntoView({ behavior: "smooth" });
@@ -618,14 +655,41 @@ const Home = () => {
       {/* ═══ SEARCH BAR ═══ */}
       <div className="wander-search-section">
         <form className="wander-search-bar" onSubmit={handleSearch}>
-          <div className="wander-sf">
+          <div className="wander-sf" style={{ position: "relative" }}>
             <div className="wander-sf-label">Where to</div>
             <input
               className="wander-sf-val"
               placeholder="Bali, Indonesia"
               value={where}
-              onChange={(e) => setWhere(e.target.value)}
+              onChange={(e) => {
+                setWhere(e.target.value);
+                if (recentSearches.length > 0) {
+                  setShowRecentSearches(true);
+                }
+              }}
+              onFocus={() => {
+                if (recentSearches.length > 0) {
+                  setShowRecentSearches(true);
+                }
+              }}
             />
+            {showRecentSearches && recentSearches.length > 0 && (
+              <div className="wander-recent-searches">
+                {recentSearches.map((search) => (
+                  <button
+                    key={search}
+                    type="button"
+                    className="wander-recent-search-item"
+                    onMouseDown={() => {
+                      setWhere(search);
+                      setShowRecentSearches(false);
+                    }}
+                  >
+                    {search}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
           <div className="wander-sf">
             <div className="wander-sf-label">Check In</div>


### PR DESCRIPTION
## 📌 Linked Issue

Closes #467

---

## 🛠 Changes Made

- Added a recently searched destinations dropdown.
- Stored recent searches using localStorage.
- Limited stored searches to the last 5 entries.
- Prevented duplicate destination entries.
- Allowed users to quickly select previously searched destinations.

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Search multiple destinations and verify they appear in the dropdown.
  - Test case 2: Refresh the page and verify recent searches persist.
  - Test case 3: Search the same destination again and verify no duplicate entry is created.
  - Test case 4: Add more than 5 searches and verify only the latest 5 are retained.

---

## 📸 UI Changes (if applicable)

| Before | After |
| ------- | ------- |
| No recent search dropdown | Recent searches dropdown displayed when the search input is focused |

---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors related to this feature
- [x] Commit messages follow Git guidelines

## 💡 Additional Notes

This feature enhances user experience by providing quick access to recently searched destinations, persisting searches using localStorage, and preventing duplicate entries.