### PR TITLE
Fix #665: Add timeout handling to getJSON() helper API requests

### DIFF
--- a/scripts/update_destinations.js
+++ b/scripts/update_destinations.js
@@ -80,10 +80,11 @@ function getCategory(name = '', type = '') {
 
 function getJSON(url) {
   return new Promise((resolve, reject) => {
-    https.get(url, {
+    const req = https.get(url, {
       headers: {
         'User-Agent': 'PackGoTravelPlannerBot/1.0 (contact@packgo.org)'
-      }
+      },
+      timeout: 10000 // 10 seconds timeout
     }, (res) => {
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
@@ -94,8 +95,15 @@ function getJSON(url) {
           reject(e);
         }
       });
-    }).on('error', (err) => {
+    });
+
+    req.on('error', (err) => {
       reject(err);
+    });
+
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Request timed out'));
     });
   });
 }


### PR DESCRIPTION
## 📌 Linked Issue

Closes #665

---

## 🛠 Changes Made

- Fixed: An issue where the `getJSON()` helper function would hang indefinitely if external APIs (like Wikipedia or Nominatim) became unresponsive.
- Added: A 10-second timeout option to the `https.get` configuration.
- Added: A `.on('timeout')` event listener to explicitly destroy the request and reject the promise, preventing the destination update script from getting stuck.

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Verified the script runs successfully when external APIs are functioning normally.
  - Test case 2: Verified that if the API does not respond within 10 seconds, the request aborts and throws a `'Request timed out'` error gracefully without crashing.

---

## 📸 UI Changes (if applicable)

| Before  | After   |
| ------- | ------- |
| N/A     | N/A     |

---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [x] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes (If any)

The `timeout` configuration is completely backward-compatible and safely catches any hanging requests.
