### PR TITLE
feat: add accessible input wrapper with aria labels

### DIFF
--- a/client/src/components/AccessibleInput.js
+++ b/client/src/components/AccessibleInput.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { TextField } from '@mui/material';
+
+export default function AccessibleInput(props) {
+  return <TextField {...props} inputProps={{ 'aria-label': props.label }} />;
+}


### PR DESCRIPTION
Closes #710 

# Summary
Introduces an accessibility-first input wrapper.

# Changes Made
- Created `client/src/components/AccessibleInput.js`.
- Passed `aria-label` automatically based on the label prop.

# Testing
- accessibility testing: Verified aria-label is present in DOM.

# Checklist
- [x] Code follows project standards
- [x] Accessibility considered
- [x] No unrelated changes included
