### PR TITLE
feat: add reusable empty state component

### DIFF
--- a/client/src/components/EmptyState.js
+++ b/client/src/components/EmptyState.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Typography, Box } from '@mui/material';
+
+export default function EmptyState({ message }) {
+  return (
+    <Box textAlign='center' mt={5}>
+      <Typography variant='h6' color='textSecondary'>{message}</Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
Closes #714 

# Summary
Introduces a reusable `EmptyState` UI component.

# Changes Made
- Created `client/src/components/EmptyState.js` using Material-UI Typography and Box.

# Testing
- local testing: Verified component renders correctly.
- responsive design verified.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] Responsive design verified
- [x] No unrelated changes included
