### PR TITLE
ci: add automated linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Linting
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm install
+        working-directory: ./client
+      - run: npm run lint
+        working-directory: ./client


### PR DESCRIPTION
Closes #724 

# Summary
Introduces a GitHub Actions workflow to automate linting.

# Changes Made
- Added `.github/workflows/lint.yml` to run `npm run lint` on the `client` directory on push and PR.

# Testing
- local testing: Verified `npm run lint` works locally.
- build verification: GitHub action runs successfully.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
