### PR TITLE
fix: search bar UX - borders, alignment, dividers

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -346,12 +346,12 @@ html {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr auto;
   overflow: hidden;
-  border: 0.5px solid rgba(26, 74, 107, 0.1);
+  border: 1.5px solid rgba(26, 74, 107, 0.4);
 }
 
 .wander-sf {
   padding: 1.4rem 1.5rem;
-  border-right: 0.5px solid rgba(26, 74, 107, 0.08);
+  border-right: 1px solid rgba(26, 74, 107, 0.3);
 }
 
 .wander-sf-label {
@@ -361,6 +361,7 @@ html {
   letter-spacing: 0.8px;
   text-transform: uppercase;
   margin-bottom: 0.3rem;
+  text-align: left;
 }
 
 .wander-sf-val {
@@ -923,7 +924,7 @@ html {
 
   .wander-sf {
     border-right: none;
-    border-bottom: 0.5px solid rgba(26, 74, 107, 0.08);
+    border-bottom: 1px solid rgba(26, 74, 107, 0.3);
   }
 
   .wander-section {
@@ -1041,7 +1042,7 @@ html {
   justify-content: center !important;
   padding: 1rem 1.75rem !important;
   height: 84px !important;
-  border-right: 1px solid rgba(26, 74, 107, 0.12) !important;
+  border-right: 1px solid rgba(26, 74, 107, 0.35) !important;
   border-bottom: none !important;
 }
 


### PR DESCRIPTION
## 📌 Linked Issue

Closes #106 

---

## 🛠 Changes Made

- Fixed: Strengthened the outer border of the search bar for better visual definition (`rgba(26, 74, 107, 0.1)` to `rgba(26, 74, 107, 0.4)`)
- Fixed: Darkened the vertical divider lines between `Where To`, `Check In`, and `Travellers` fields (`rgba(26, 74, 107, 0.08)` to `rgba(26, 74, 107, 0.35)`)
- Updated: Added `text-align: left` to `.wander-sf-label` for consistent left-alignment of field labels
- Updated: Applied same divider contrast fix to mobile (`max-width: 900px`) breakpoint for responsive consistency

---

## 🧪 Testing

- [x] Tested manually (described below):
  - Test case 1: Opened homepage on desktop : Search bar now has a clearly visible border and distinct field separators
  - Test case 2: Verified labels (`WHERE TO`, `CHECK IN`, `TRAVELLERS`) are left-aligned consistently
  - Test case 3: Resized browser to mobile width : Dividers switch to bottom borders correctly with improved contrast

---

## 📸 UI Changes

### Before 

<img width="1919" height="925" alt="image" src="https://github.com/user-attachments/assets/7073dbe4-eeda-4fba-b1ff-40384e186f49" />

### After

<img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/18446c79-105c-483c-954d-7cfefc882543" />

---

## ✅ Checklist

- [x] Created a new branch for PR
- [ ] Have starred the repository 
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)
