### PR TITLE
fix(auth): prevent email update in updateProfile and enforce schema v…

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -122,15 +122,24 @@ exports.getProfile = async (req, res, next) => {
 // Update user profile
 exports.updateProfile = async (req, res, next) => {
   try {
-    const { name, email } = req.body;
+    const { name, baseCurrency } = req.body;
     const updateFields = {};
-    if (name) updateFields.name = name;
-    if (email) updateFields.email = email;
+    if (name !== undefined) {
+      updateFields.name = name.trim().replace(/\s+/g, " ");
+    }
+    if (baseCurrency !== undefined) {
+      updateFields.baseCurrency = baseCurrency;
+    }
+
+    if (Object.keys(updateFields).length === 0) {
+      const user = await User.findById(req.user.id).select("-password");
+      return res.json(user);
+    }
 
     const user = await User.findByIdAndUpdate(
       req.user.id,
       { $set: updateFields },
-      { new: true },
+      { new: true, runValidators: true },
     ).select("-password");
 
     res.json(user);


### PR DESCRIPTION
### Description
Closes #778 

This Pull Request fixes a security bypass and data validation bug in the user profile update route. 

The `updateProfile` endpoint allowed direct modification of a user's email address bypassing the secure OTP email verification endpoints (`requestEmailChange` & `verifyEmailChange`). Furthermore, Mongoose did not run schema-level constraints on update (e.g. name length/format checks) because `{ runValidators: true }` was omitted from `findByIdAndUpdate`.

### Changes Made
- **Removed Email Modification:** Excluded the `email` field from updates in `updateProfile` to force users to use the secure OTP change workflow.
- **Enforced Schema Validation:** Added `{ runValidators: true }` to the `findByIdAndUpdate` options in `updateProfile` to ensure name constraints are evaluated before saving.
- **Name Input Normalization:** Trimmed user names and collapsed multiple consecutive spaces (e.g., `"John   Doe"` becomes `"John Doe"`), matching the registration behavior.
- **Added Forward Compatibility:** Allowed updates to the user's `baseCurrency` profile setting.
- **Optimization:** Added a fast-return check; if no fields are modified, the endpoint returns the profile directly without a database write.

### Verification Done
- Verified that name length validations (e.g., name < 2 characters) trigger a `ValidationError` (400 Bad Request) instead of saving successfully.
- Verified that attempting to pass an `email` field is ignored by the endpoint.
- Checked that profile data updates correctly when valid name/baseCurrency parameters are provided.
