### PR TITLE
Add recent destination searches

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -1125,3 +1125,56 @@ html {
     height: 52px !important;
   }
 }
+.wander-recent-searches {
+  max-width: 980px;
+  margin: 1rem auto 0;
+  padding: 0 1rem;
+}
+
+.wander-recent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ocean);
+}
+
+.wander-recent-header button {
+  border: none;
+  background: transparent;
+  color: var(--coral);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wander-recent-header button:hover {
+  text-decoration: underline;
+}
+
+.wander-recent-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.wander-recent-chip {
+  border: 1px solid rgba(26, 74, 107, 0.18);
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--ocean);
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.wander-recent-chip:hover {
+  transform: translateY(-2px);
+  background: var(--white);
+  box-shadow: 0 8px 20px rgba(26, 74, 107, 0.12);
+}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -5,6 +5,7 @@ import "./Home.css";
 import api from "../services/api";
 import { addTrip } from "../redux/actions/tripActions";
 import { FaFacebook, FaInstagram, FaTwitter } from "react-icons/fa";
+
 /* ── SVG SCENES ─────────────────────────────────────────────── */
 const SceneIceland = () => (
   <svg
@@ -357,6 +358,7 @@ const Home = () => {
   const [destinations, setDestinations] = useState([]);
   const [loading, setLoading] = useState(true);
   const [where, setWhere] = useState("");
+  const [recentSearches, setRecentSearches] = useState([]);
   const [checkIn, setCheckIn] = useState("");
   const [travellers, setTravellers] = useState("");
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -376,6 +378,13 @@ const Home = () => {
         setLoading(false);
       })
       .catch(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const savedSearches =
+      JSON.parse(localStorage.getItem("recentDestinationSearches")) || [];
+
+    setRecentSearches(savedSearches);
   }, []);
 
   useEffect(() => {
@@ -407,8 +416,34 @@ const Home = () => {
     navigate("/dashboard/trips");
   };
 
+  const saveRecentSearch = (destination) => {
+    const trimmedDestination = destination.trim();
+
+    if (!trimmedDestination) return;
+
+    const updatedSearches = [
+      trimmedDestination,
+      ...recentSearches.filter(
+        (item) => item.toLowerCase() !== trimmedDestination.toLowerCase(),
+      ),
+    ].slice(0, 5);
+
+    setRecentSearches(updatedSearches);
+    localStorage.setItem(
+      "recentDestinationSearches",
+      JSON.stringify(updatedSearches),
+    );
+  };
+
+  const clearRecentSearches = () => {
+    setRecentSearches([]);
+    localStorage.removeItem("recentDestinationSearches");
+  };
+
   const handleSearch = (e) => {
     e.preventDefault();
+    saveRecentSearch(where);
+
     document
       .getElementById("wander-dest-section")
       ?.scrollIntoView({ behavior: "smooth" });
@@ -627,6 +662,7 @@ const Home = () => {
               onChange={(e) => setWhere(e.target.value)}
             />
           </div>
+
           <div className="wander-sf">
             <div className="wander-sf-label">Check In</div>
 
@@ -652,6 +688,7 @@ const Home = () => {
               </span>
             </div>
           </div>
+
           <div className="wander-sf">
             <div className="wander-sf-label">Travellers</div>
             <input
@@ -661,10 +698,42 @@ const Home = () => {
               onChange={(e) => setTravellers(e.target.value)}
             />
           </div>
+
           <button type="submit" className="wander-search-btn">
             <SearchIcon /> Search
           </button>
         </form>
+
+        {recentSearches.length > 0 && (
+          <div className="wander-recent-searches">
+            <div className="wander-recent-header">
+              <span>Recent Searches</span>
+              <button type="button" onClick={clearRecentSearches}>
+                Clear
+              </button>
+            </div>
+
+            <div className="wander-recent-list">
+              {recentSearches.map((item) => (
+                <button
+                  type="button"
+                  key={item}
+                  className="wander-recent-chip"
+                  onClick={() => {
+                    setWhere(item);
+                    saveRecentSearch(item);
+
+                    document
+                      .getElementById("wander-dest-section")
+                      ?.scrollIntoView({ behavior: "smooth" });
+                  }}
+                >
+                  {item}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* ═══ DESTINATIONS ═══ */}
@@ -942,7 +1011,6 @@ const Home = () => {
           </div>
 
           <div className="wander-footer-socials">
-            {/* Social media icons */}
             <a href="/" aria-label="Facebook">
               <FaFacebook />
             </a>


### PR DESCRIPTION
## What I changed

* Added a Recent Searches section for destination searches.
* Stored recent destination searches in localStorage.
* Displayed up to 5 latest searches below the homepage search bar.
* Prevented duplicate searches by moving repeated searches to the top.
* Added a Clear button to remove all recent searches.
* Added styling for recent search chips and hover effects.

## Testing

* Tested searching destinations from the homepage search bar.
* Verified that recent searches appear after clicking Search.
* Verified that recent searches persist after page refresh.
* Tested duplicate search handling.
* Tested the Clear button functionality.
* Ran `npm run build` successfully.
