### PR TITLE
fix(trip): add date chronological validation in Trip model and update…

### DIFF
--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -115,11 +115,8 @@ exports.updateTrip = async (req, res) => {
       }
     }
 
-    trip = await Trip.findByIdAndUpdate(
-      req.params.id,
-      { $set: updateData },
-      { new: true },
-    );
+    trip.set(updateData);
+    await trip.save();
 
     res.json(trip);
   } catch (err) {

--- a/server/models/Trip.js
+++ b/server/models/Trip.js
@@ -75,4 +75,37 @@ const TripSchema = new mongoose.Schema({
   },
 });
 
+// Enforce chronological date ordering constraints
+TripSchema.pre("validate", function (next) {
+  if (this.startDate && this.endDate && this.endDate < this.startDate) {
+    this.invalidate("endDate", "End date must be on or after the start date.");
+  }
+
+  if (
+    this.accommodation &&
+    this.accommodation.checkIn &&
+    this.accommodation.checkOut &&
+    this.accommodation.checkOut < this.accommodation.checkIn
+  ) {
+    this.invalidate(
+      "accommodation.checkOut",
+      "Accommodation check-out date must be on or after the check-in date.",
+    );
+  }
+
+  if (
+    this.transportation &&
+    this.transportation.departureTime &&
+    this.transportation.arrivalTime &&
+    this.transportation.arrivalTime < this.transportation.departureTime
+  ) {
+    this.invalidate(
+      "transportation.arrivalTime",
+      "Transportation arrival time must be on or after the departure time.",
+    );
+  }
+
+  next();
+});
+
 module.exports = mongoose.model("Trip", TripSchema);


### PR DESCRIPTION
---
name: "📦 Pull Request"
about: Submit changes for review
title: "PR: Add chronological date order validations for trips, accommodation, and transportation"
labels: "bug, backend, validation"
assignees: ""
---

## 📌 Linked Issue


Closes #780

---

## 🛠 Changes Made

- Added: A `pre('validate')` hook to the `Trip` schema enforcing chronological order for trip dates, accommodation check-in/out dates, and transportation departure/arrival dates.
- Fixed: Redundant `findByIdAndUpdate` usage in `updateTrip` that bypassed database hooks and validators during updates.
- Updated: `updateTrip` controller to retrieve, set, and save the document via Mongoose standard `trip.set()` and `trip.save()`.

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - **Test case 1:** Create or update a trip with a `startDate` of `2026-06-15` and `endDate` of `2026-06-05`.
    * **Expected Result:** Validation fails with a 400 status and throws `ValidationError: End date must be on or after the start date.`
  - **Test case 2:** Add accommodation check-out date prior to check-in date during trip creation/update.
    * **Expected Result:** Validation fails with a 400 status and throws `ValidationError: Accommodation check-out date must be on or after the check-in date.`

---

## 📸 UI Changes (if applicable)

| Before  | After   |
| ------- | ------- |
| N/A | N/A |

---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [x] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes (If any)

No breaking changes; this improves API integrity and catches chronological mistakes on the backend instead of saving invalid dates to MongoDB.
