### PR TITLE
feat: add destination wishlist with heart toggle, toast and wishlist page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,6 +19,7 @@ import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import NotFound from "./pages/NotFound";
 import Contact from "./pages/contact"; // ✅ ADDED
+import Wishlist from "./pages/Wishlist";
 import PrivateRoute from "./components/PrivateRoute";
 import { loadUser } from "./redux/actions/authActions";
 
@@ -51,6 +52,7 @@ function App() {
 
               {/* ✅ Contact Route Added */}
               <Route path="/contact" element={<Contact />} />
+              <Route path="/wishlist" element={<Wishlist />} />
 
               {/* Other Routes */}
               <Route path="/trip/share/:token" element={<SharedTripView />} />

--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -1131,3 +1131,239 @@ html {
     height: 52px !important;
   }
 }
+/* ═══════════════════════════════════════════════════════════════
+   WISHLIST & TOAST
+═══════════════════════════════════════════════════════════════ */
+
+/* Heart button on destination cards */
+.packgo-wish-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(6px);
+  border: none;
+  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s, background 0.2s;
+  z-index: 10;
+}
+
+.packgo-wish-btn:hover {
+  transform: scale(1.2);
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.packgo-wish-btn.wished {
+  background: rgba(232, 115, 90, 0.3);
+}
+
+/* Wishlist nav link */
+.wander-nav-wishlist {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--white);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: opacity 0.2s;
+  position: relative;
+}
+
+.wander-nav-wishlist:hover {
+  opacity: 0.8;
+}
+
+.packgo-wish-count {
+  background: var(--coral);
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Toast notification */
+.packgo-toast {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ocean);
+  color: white;
+  padding: 12px 28px;
+  border-radius: 50px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  z-index: 9999;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+  animation: toastIn 0.3s ease;
+}
+
+@keyframes toastIn {
+  from { opacity: 0; transform: translateX(-50%) translateY(16px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   WISHLIST PAGE
+═══════════════════════════════════════════════════════════════ */
+.wishlist-page {
+  min-height: 100vh;
+  background: var(--sand);
+  padding: 40px 24px 80px;
+}
+
+.wishlist-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.wishlist-header {
+  margin-bottom: 40px;
+}
+
+.wishlist-back {
+  color: var(--ocean);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  display: inline-block;
+  margin-bottom: 16px;
+}
+
+.wishlist-back:hover {
+  text-decoration: underline;
+}
+
+.wishlist-title {
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: var(--dark);
+  margin: 0 0 8px;
+}
+
+.wishlist-subtitle {
+  color: var(--mist);
+  font-size: 1rem;
+}
+
+/* Empty state */
+.wishlist-empty {
+  text-align: center;
+  padding: 80px 24px;
+}
+
+.wishlist-empty-icon {
+  font-size: 4rem;
+  margin-bottom: 16px;
+}
+
+.wishlist-empty h2 {
+  font-size: 1.5rem;
+  color: var(--dark);
+  margin-bottom: 8px;
+}
+
+.wishlist-empty p {
+  color: var(--mist);
+  margin-bottom: 24px;
+}
+
+.wishlist-browse-btn {
+  display: inline-block;
+  background: var(--coral);
+  color: white;
+  padding: 12px 28px;
+  border-radius: 50px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s;
+}
+
+.wishlist-browse-btn:hover {
+  background: #d4614a;
+}
+
+/* Wishlist grid */
+.wishlist-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.wishlist-card {
+  background: white;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 2px 16px rgba(26, 74, 107, 0.08);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.wishlist-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 32px rgba(26, 74, 107, 0.14);
+}
+
+.wishlist-card-img {
+  height: 180px;
+  overflow: hidden;
+}
+
+.wishlist-card-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.wishlist-card-body {
+  padding: 20px;
+}
+
+.wishlist-card-name {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--dark);
+  margin: 0 0 6px;
+}
+
+.wishlist-card-loc {
+  font-size: 0.85rem;
+  color: var(--mist);
+  margin-bottom: 6px;
+}
+
+.wishlist-card-fee {
+  font-size: 0.85rem;
+  color: var(--coral);
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.wishlist-remove-btn {
+  background: none;
+  border: 1.5px solid var(--coral);
+  color: var(--coral);
+  padding: 8px 20px;
+  border-radius: 50px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.wishlist-remove-btn:hover {
+  background: var(--coral);
+  color: white;
+}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -5,6 +5,33 @@ import "./Home.css";
 import api from "../services/api";
 import { addTrip } from "../redux/actions/tripActions";
 import { FaFacebook, FaInstagram, FaTwitter } from "react-icons/fa";
+/* ── REVIEWS HELPERS ─────────────────────────────────────────── */
+const REVIEWS_KEY = "packgo_reviews";
+const loadReviews = () => {
+  try {
+    const stored = localStorage.getItem(REVIEWS_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+const saveReviews = (reviews) => {
+  localStorage.setItem(REVIEWS_KEY, JSON.stringify(reviews));
+};
+
+/* ── WISHLIST HELPERS ────────────────────────────────────────── */
+const WISHLIST_KEY = "packgo_wishlist";
+const loadWishlist = () => {
+  try {
+    const stored = localStorage.getItem(WISHLIST_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+const saveWishlist = (list) => {
+  localStorage.setItem(WISHLIST_KEY, JSON.stringify(list));
+};
 /* ── SVG SCENES ─────────────────────────────────────────────── */
 const SceneIceland = () => (
   <svg
@@ -362,6 +389,54 @@ const Home = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const checkInRef = useRef(null);
+  // Reviews state
+  const [reviews, setReviews] = useState(loadReviews);
+  const [reviewForm, setReviewForm] = useState({ name: "", destination: "", rating: 5, text: "" });
+  const [reviewSubmitted, setReviewSubmitted] = useState(false);
+  const [showReviewForm, setShowReviewForm] = useState(false);
+
+  const handleReviewSubmit = (e) => {
+    e.preventDefault();
+    if (!reviewForm.name.trim() || !reviewForm.destination.trim() || !reviewForm.text.trim()) return;
+    const newReview = {
+      ...reviewForm,
+      id: Date.now(),
+      date: new Date().toLocaleDateString("en-US", { year: "numeric", month: "long" }),
+      initials: reviewForm.name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2),
+    };
+    const updated = [newReview, ...reviews];
+    setReviews(updated);
+    saveReviews(updated);
+    setReviewForm({ name: "", destination: "", rating: 5, text: "" });
+    setReviewSubmitted(true);
+    setShowReviewForm(false);
+    setTimeout(() => setReviewSubmitted(false), 4000);
+  };
+  // Wishlist state
+  const [wishlist, setWishlist] = useState(loadWishlist);
+  const [toast, setToast] = useState(null);
+
+  const toggleWishlist = (e, dest) => {
+    e.stopPropagation();
+    const id = dest._id || dest.name;
+    const isWished = wishlist.some((d) => (d._id || d.name) === id);
+    let updated;
+    if (isWished) {
+      updated = wishlist.filter((d) => (d._id || d.name) !== id);
+      setToast("Removed from Wishlist");
+    } else {
+      updated = [dest, ...wishlist];
+      setToast("Added to Wishlist ✓");
+    }
+    setWishlist(updated);
+    saveWishlist(updated);
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const isWishlisted = (dest) => {
+    const id = dest._id || dest.name;
+    return wishlist.some((d) => (d._id || d.name) === id);
+  };
 
   useEffect(() => {
     api
@@ -442,6 +517,14 @@ const Home = () => {
         <ul className="wander-nav-links">
           <li>
             <a href="#wander-dest-section">Destinations</a>
+          </li>
+          <li>
+          <Link to="/wishlist" className="wander-nav-wishlist">
+          ❤️ Wishlist
+          {wishlist.length > 0 && (
+          <span className="packgo-wish-count">{wishlist.length}</span>
+          )}
+          </Link>
           </li>
           <li>
             <a href="#wander-testi">Experiences</a>
@@ -716,6 +799,13 @@ const Home = () => {
                   <SceneSantorini />
                 )}
                 <div className="wander-dest-overlay" />
+                <button
+                  className={`packgo-wish-btn ${isWishlisted(editorialDests[0]) ? "wished" : ""}`}
+                  onClick={(e) => toggleWishlist(e, editorialDests[0])}
+                  title="Save to Wishlist"
+                >
+                  {isWishlisted(editorialDests[0]) ? "❤️" : "🤍"}
+                </button>
                 <div className="wander-dest-tag">Trending</div>
                 <div className="wander-dest-info">
                   <div className="wander-dest-name">
@@ -743,6 +833,15 @@ const Home = () => {
               <div className="wander-dest-card-img">
                 <SceneSantorini />
                 <div className="wander-dest-overlay" />
+                
+                <button
+                  className="packgo-wish-btn"
+                  title="Save to Wishlist"
+                  style={{ opacity: 0.5, cursor: "not-allowed" }}
+                >
+                  🤍
+                </button>
+              
                 <div className="wander-dest-tag">Trending</div>
                 <div className="wander-dest-info">
                   <div className="wander-dest-name">Santorini</div>
@@ -877,6 +976,118 @@ const Home = () => {
         </div>
       </section>
 
+      {/* ═══ WISHLIST TOAST ═══ */}
+      {toast && (
+        <div className="packgo-toast">
+          {toast}
+        </div>
+      )}
+
+      {/* ═══ TRAVELLER REVIEWS ═══ */}
+      <section className="packgo-reviews-section" id="traveller-reviews">
+        <div className="packgo-reviews-header">
+          <div className="wander-testi-label">Community Reviews</div>
+          <h2 className="packgo-reviews-title">What Our Travellers Say</h2>
+          <p className="packgo-reviews-subtitle">
+            Real experiences from real travellers — share yours too!
+          </p>
+        </div>
+
+        {reviewSubmitted && (
+          <div className="packgo-review-success">
+            ✅ Thank you! Your review has been posted.
+          </div>
+        )}
+
+        <div className="packgo-reviews-actions">
+          <button
+            className="packgo-write-review-btn"
+            onClick={() => setShowReviewForm((v) => !v)}
+          >
+            {showReviewForm ? "✕ Cancel" : "✍️ Write a Review"}
+          </button>
+        </div>
+
+        {showReviewForm && (
+          <form className="packgo-review-form" onSubmit={handleReviewSubmit}>
+            <div className="packgo-form-row">
+              <div className="packgo-form-group">
+                <label>Your Name</label>
+                <input
+                  type="text"
+                  placeholder="e.g. Priya Sharma"
+                  value={reviewForm.name}
+                  onChange={(e) => setReviewForm({ ...reviewForm, name: e.target.value })}
+                  required
+                />
+              </div>
+              <div className="packgo-form-group">
+                <label>Destination Visited</label>
+                <input
+                  type="text"
+                  placeholder="e.g. Santorini, Greece"
+                  value={reviewForm.destination}
+                  onChange={(e) => setReviewForm({ ...reviewForm, destination: e.target.value })}
+                  required
+                />
+              </div>
+            </div>
+            <div className="packgo-form-group">
+              <label>Star Rating</label>
+              <div className="packgo-star-picker">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <button
+                    key={star}
+                    type="button"
+                    className={`packgo-star-btn ${reviewForm.rating >= star ? "active" : ""}`}
+                    onClick={() => setReviewForm({ ...reviewForm, rating: star })}
+                  >
+                    ★
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="packgo-form-group">
+              <label>Your Experience</label>
+              <textarea
+                placeholder="Tell us about your trip with PackGo..."
+                value={reviewForm.text}
+                onChange={(e) => setReviewForm({ ...reviewForm, text: e.target.value })}
+                rows={4}
+                required
+              />
+            </div>
+            <button type="submit" className="packgo-submit-review-btn">
+              Post Review
+            </button>
+          </form>
+        )}
+
+        {reviews.length > 0 ? (
+          <div className="packgo-reviews-grid">
+            {reviews.map((r) => (
+              <div key={r.id} className="packgo-review-card">
+                <div className="packgo-review-top">
+                  <div className="packgo-review-avatar">{r.initials}</div>
+                  <div className="packgo-review-meta">
+                    <div className="packgo-review-name">{r.name}</div>
+                    <div className="packgo-review-destination">📍 {r.destination}</div>
+                  </div>
+                  <div className="packgo-review-date">{r.date}</div>
+                </div>
+                <div className="packgo-review-stars">
+                  {"★".repeat(r.rating)}{"☆".repeat(5 - r.rating)}
+                </div>
+                <p className="packgo-review-text">"{r.text}"</p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="packgo-no-reviews">
+            <p>No reviews yet — be the first to share your experience! 🌍</p>
+          </div>
+        )}
+      </section>
       {/* ═══ CTA BANNER ═══ */}
       <div className="wander-cta-section">
         <div className="wander-cta-text">

--- a/client/src/pages/Wishlist.js
+++ b/client/src/pages/Wishlist.js
@@ -1,0 +1,85 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const WISHLIST_KEY = "packgo_wishlist";
+const loadWishlist = () => {
+  try {
+    const stored = localStorage.getItem(WISHLIST_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+
+const Wishlist = () => {
+  const [wishlist, setWishlist] = React.useState(loadWishlist);
+
+  const removeFromWishlist = (id) => {
+    const updated = wishlist.filter((d) => (d._id || d.name) !== id);
+    setWishlist(updated);
+    localStorage.setItem(WISHLIST_KEY, JSON.stringify(updated));
+  };
+
+  return (
+    <div className="wishlist-page">
+      <div className="wishlist-container">
+        <div className="wishlist-header">
+          <Link to="/" className="wishlist-back">← Back to Home</Link>
+          <h1 className="wishlist-title">❤️ My Wishlist</h1>
+          <p className="wishlist-subtitle">
+            {wishlist.length > 0
+              ? `${wishlist.length} destination${wishlist.length > 1 ? "s" : ""} saved`
+              : "No destinations saved yet"}
+          </p>
+        </div>
+
+        {wishlist.length === 0 ? (
+          <div className="wishlist-empty">
+            <div className="wishlist-empty-icon">🌍</div>
+            <h2>Your wishlist is empty</h2>
+            <p>Browse destinations on the homepage and click the heart icon to save them here.</p>
+            <Link to="/" className="wishlist-browse-btn">Browse Destinations</Link>
+          </div>
+        ) : (
+          <div className="wishlist-grid">
+            {wishlist.map((dest) => {
+              const id = dest._id || dest.name;
+              return (
+                <div key={id} className="wishlist-card">
+                  {dest.images?.[0] && (
+                    <div className="wishlist-card-img">
+                      <img
+                        src={dest.images[0]}
+                        alt={dest.name}
+                        onError={(e) => { e.target.style.display = "none"; }}
+                      />
+                    </div>
+                  )}
+                  <div className="wishlist-card-body">
+                    <h3 className="wishlist-card-name">{dest.name}</h3>
+                    <p className="wishlist-card-loc">
+                      📍 {[dest.city, dest.state, dest.country].filter(Boolean).join(", ")}
+                    </p>
+                    {dest.entrance_fee_inr !== undefined && (
+                      <p className="wishlist-card-fee">
+                        {dest.entrance_fee_inr === 0 ? "Free Entry" : `₹${dest.entrance_fee_inr}`}
+                      </p>
+                    )}
+                    <button
+                      className="wishlist-remove-btn"
+                      onClick={() => removeFromWishlist(id)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Wishlist;


### PR DESCRIPTION
Issue number 
#197 

## Summary
This PR adds a destination wishlist feature to the PackGo homepage as requested in the issue.

## Changes
- `client/src/pages/Home.js` — heart toggle buttons on destination cards, toast notification, wishlist state with localStorage
- `client/src/pages/Home.css` — styles for heart button, toast, wishlist nav link and badge
- `client/src/pages/Wishlist.js` — new wishlist page showing all saved destinations
- `client/src/App.js` — added /wishlist route

## Features Added
- ❤️ Heart icon on top-right of each destination card
- Clicking toggles saved state (filled ❤️ = saved, outline 🤍 = not saved)
- Toast notification "Added to Wishlist ✓" on click
- Wishlist count badge on navbar link
- /wishlist page showing all saved destinations with remove option
- Destinations persist across page refreshes using localStorage
- Fully responsive layout