### PR TITLE
## fix: Reset Password broken — `useParams().token` always `undefined` (#837)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -58,7 +58,7 @@ function App() {
               <Route path="/trip/share/:token" element={<SharedTripView />} />
               <Route path="/shared-trip/:token" element={<SharedTripView />} />
               <Route path="/forgot-password" element={<ForgotPassword />} />
-              <Route path="/reset-password" element={<ResetPassword />} />
+              <Route path="/reset-password/:token" element={<ResetPassword />} />
               {/* Fallback */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -58,7 +58,10 @@ function App() {
               <Route path="/trip/share/:token" element={<SharedTripView />} />
               <Route path="/shared-trip/:token" element={<SharedTripView />} />
               <Route path="/forgot-password" element={<ForgotPassword />} />
-              <Route path="/reset-password/:token" element={<ResetPassword />} />
+              <Route
+                path="/reset-password/:token"
+                element={<ResetPassword />}
+              />
               {/* Fallback */}
               <Route path="*" element={<NotFound />} />
             </Routes>


### PR DESCRIPTION

### Linked Issue
Closes #837

### Problem
The server generates password reset links as `/reset-password/<token>`, but the
client route was defined without the `:token` param — causing `useParams().token`
to always return `undefined` and every reset attempt to fail with `"Invalid token"`.

### Change
**`client/src/App.js` — Line 61**
```diff
- <Route path="/reset-password" element={<ResetPassword />} />
+ <Route path="/reset-password/:token" element={<ResetPassword />} />
