### PR TITLE
## fix: `updateProfile` — remove email field to enforce OTP email-change flow (#839)

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -126,18 +126,32 @@ exports.getProfile = async (req, res, next) => {
   }
 };
 
-// Update user profile
+// Update user profile (name only)
+// Email changes must use the dedicated OTP flow: POST /request-email-change → POST /verify-email-change
 exports.updateProfile = async (req, res, next) => {
   try {
-    const { name, email } = req.body;
-    const updateFields = {};
-    if (name) updateFields.name = name;
-    if (email) updateFields.email = email;
+    const { name } = req.body;
+
+    if (!name || name.trim().length < 2) {
+      return res
+        .status(400)
+        .json({ msg: "Name must be at least 2 characters" });
+    }
+
+    if (!/^[A-Za-z\s]+$/.test(name.trim())) {
+      return res
+        .status(400)
+        .json({ msg: "Name can only contain letters and spaces" });
+    }
+
+    const updateFields = {
+      name: name.trim().replace(/\s+/g, " "),
+    };
 
     const user = await User.findByIdAndUpdate(
       req.user.id,
       { $set: updateFields },
-      { new: true },
+      { new: true, runValidators: true },
     ).select("name email date isVerified");
 
     res.json(user);


### PR DESCRIPTION

### Linked Issue
Closes #839

### Problem
`PUT /api/auth/profile` accepted an `email` field and updated it directly in the
database — no OTP, no uniqueness check, no validation. This silently bypassed the
entire secure email-change flow (`/request-email-change` → OTP →
`/verify-email-change`) with a single API call.

### Changes
**`server/controllers/authController.js`**

```diff
- const { name, email } = req.body;
- if (name) updateFields.name = name;
- if (email) updateFields.email = email;      // ← bypassed OTP flow
+ const { name } = req.body;                  // email removed entirely
+ // name validation: min 2 chars, letters only
+ const updateFields = { name: name.trim().replace(/\s+/g, " ") };
