### PR TITLE
test(client): add coverage for budget and trip countdown utilities

### DIFF
--- a/client/src/utils/budgetUtils.test.js
+++ b/client/src/utils/budgetUtils.test.js
@@ -1,0 +1,83 @@
+import { calculateBudget, formatINR, pct } from "./budgetUtils";
+
+describe("calculateBudget", () => {
+  it("calculates itemized totals, buffer, per-day, per-person, and ranges", () => {
+    const result = calculateBudget({
+      days: 5,
+      travelers: 2,
+      accommodationType: "standard",
+      transportType: "bus",
+      foodPerPersonPerDay: 600,
+      activityType: "sightseeing",
+      baseAccomRate: 1800,
+    });
+
+    expect(result).toEqual({
+      stay: 18000,
+      travel: 3200,
+      food: 6000,
+      activities: 3000,
+      buffer: 3020,
+      total: 33220,
+      perDay: 6644,
+      perPerson: 16610,
+      ranges: {
+        budget: 18271,
+        standard: 33220,
+        luxury: 106304,
+      },
+    });
+  });
+
+  it("falls back to standard accommodation and default options for unknown keys", () => {
+    const result = calculateBudget({
+      days: 1,
+      travelers: 1,
+      accommodationType: "unknown",
+      transportType: "unknown",
+      foodPerPersonPerDay: 500,
+      activityType: "unknown",
+      baseAccomRate: 1000,
+    });
+
+    expect(result.stay).toBe(1000);
+    expect(result.travel).toBe(1600);
+    expect(result.activities).toBe(300);
+    expect(result.total).toBe(3740);
+  });
+
+  it("returns zero per-day and per-person values for zero days or travelers", () => {
+    const result = calculateBudget({
+      days: 0,
+      travelers: 0,
+      accommodationType: "standard",
+      transportType: "bus",
+      foodPerPersonPerDay: 600,
+      activityType: "sightseeing",
+      baseAccomRate: 1800,
+    });
+
+    expect(result.perDay).toBe(0);
+    expect(result.perPerson).toBe(0);
+  });
+});
+
+describe("formatINR", () => {
+  it("formats whole-number INR amounts without decimal digits", () => {
+    expect(formatINR(33220)).toBe("₹33,220");
+  });
+});
+
+describe("pct", () => {
+  it("returns a rounded percentage string", () => {
+    expect(pct(25, 200)).toBe("13%");
+  });
+
+  it("caps percentages at 100", () => {
+    expect(pct(250, 200)).toBe("100%");
+  });
+
+  it("returns 0% when total is missing or zero", () => {
+    expect(pct(50, 0)).toBe("0%");
+  });
+});

--- a/client/src/utils/tripCountdown.test.js
+++ b/client/src/utils/tripCountdown.test.js
@@ -1,0 +1,52 @@
+import { getTripCountdown } from "./tripCountdown";
+
+const localDate = (year, monthIndex, day) => new Date(year, monthIndex, day);
+
+describe("getTripCountdown", () => {
+  beforeEach(() => {
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(localDate(2026, 5, 5));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns an upcoming countdown before the trip starts", () => {
+    expect(
+      getTripCountdown(localDate(2026, 5, 10), localDate(2026, 5, 15)),
+    ).toEqual({
+      type: "upcoming",
+      label: "5 days to go",
+    });
+  });
+
+  it("returns today when the trip starts on the current day", () => {
+    const result = getTripCountdown(
+      localDate(2026, 5, 5),
+      localDate(2026, 5, 8),
+    );
+
+    expect(result.type).toBe("today");
+    expect(result.label).toContain("Trip starts today");
+  });
+
+  it("returns ongoing after the trip starts and before it ends", () => {
+    const result = getTripCountdown(
+      localDate(2026, 5, 1),
+      localDate(2026, 5, 8),
+    );
+
+    expect(result.type).toBe("ongoing");
+    expect(result.label).toContain("Trip in progress");
+  });
+
+  it("returns completed after the trip end date has passed", () => {
+    expect(
+      getTripCountdown(localDate(2026, 4, 20), localDate(2026, 5, 4)),
+    ).toEqual({
+      type: "completed",
+      label: "Completed",
+    });
+  });
+});


### PR DESCRIPTION
Before Adding Unit Testing
<img width="1737" height="962" alt="Screenshot 2026-06-24 041231" src="https://github.com/user-attachments/assets/ab18fd67-c51f-4aeb-9b87-b022edf10219" />


After Adding Unit Testing 
<img width="1260" height="942" alt="Screenshot 2026-06-24 041550" src="https://github.com/user-attachments/assets/dd3674fe-6a7e-4029-af6a-25ffb2d12230" />
<img width="1273" height="912" alt="Screenshot 2026-06-24 041534" src="https://github.com/user-attachments/assets/5bbc0182-d7dc-409b-8e13-b40dce7c4e8b" />

This PR adds unit test coverage for the budget calculation and trip countdown utility modules.

The budget utility tests verify:

* Itemized budget calculations, including stay, travel, food, activities, buffer, total cost, per-day cost, per-person cost, and budget ranges.
* Fallback behavior when unsupported accommodation, transport, or activity types are provided.
* Handling of edge cases where days or travelers are zero.
* INR currency formatting.
* Percentage calculations, including rounding, percentage capping, and zero-total handling.

The trip countdown tests verify:

* Upcoming trips and countdown calculation.
* Trips that start on the current day.
* Ongoing trips.
* Completed trips after the end date has passed.

The countdown tests use a fixed system date to ensure deterministic and repeatable test results.

No production code was modified. Changes are limited to adding test coverage for existing utility functions.

