### PR TITLE
Fix: Improve color contrast for search bar labels (#310)Fix: Improve color contrast for search bar labels (#310)

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -351,7 +351,7 @@ html {
 .wander-sf-label {
   font-size: 0.7rem;
   font-weight: 500;
-  color: var(--mist);
+  color: #4a5568;
   letter-spacing: 0.8px;
   text-transform: uppercase;
   margin-bottom: 0.3rem;


### PR DESCRIPTION
- Changed .wander-sf-label color from var(--mist) to #4a5568
- Enhances readability and meets WCAG AA contrast standards

---
name: "📦 Pull Request"
about: Submit changes for review
title: PR: Fix: Improve color contrast for search bar labels (#310)
labels: good first issue, level:beginner, GSSoC26
assignees: ""
---

## 📌 Linked Issue

Closes #310

---

## 🛠 Changes Made

- Fixed: Improved color contrast for search bar labels (WHERE TO, CHECK IN, TRAVELLERS)
- Changed `.wander-sf-label` color from `var(--mist)` to `#4a5568`
- Enhances readability and meets WCAG AA contrast standards

---

## 🧪 Testing

- [x] Tested manually - Verified labels are now readable with improved contrast

---

## 📝 Documentation Updates

- [x] Change follows WCAG AA accessibility standards

---

## ✅ Checklist

- [x] Created a new branch for PR
- [ ✅] Have starred the repository ⭐
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes (If any)
This fix addresses the accessibility issue where search bar labels had poor color contrast against the white background. The new color (#4a5568) provides sufficient contrast ratio for WCAG AA compliance.
