### PR TITLE
Fix search button layout below 900px viewport width.

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -954,6 +954,11 @@ html {
     border-bottom: 0.5px solid rgba(26, 74, 107, 0.08);
   }
 
+  .wander-search-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
   .wander-section {
     padding: 3rem 1.5rem;
   }
@@ -1105,15 +1110,21 @@ html {
 @media (max-width: 900px) {
   .wander-page .wander-search-bar {
     flex-direction: column !important;
+    align-items: stretch !important;
   }
   .wander-page .wander-sf {
     flex: 1 1 100% !important;
     width: 100% !important;
+    height: auto !important;
     border-right: none !important;
     border-bottom: 1px solid rgba(26, 74, 107, 0.08) !important;
     padding: 1.2rem 1.5rem !important;
   }
   .wander-page .wander-search-btn {
+    flex: 1 1 100% !important;
+    width: 100% !important;
     height: 52px !important;
+    align-self: stretch !important;
+    justify-content: center !important;
   }
 }


### PR DESCRIPTION
Stretch the search button full-width on mobile by overriding align-items and adding responsive width rules.
---

## 📌 Linked Issue



Closes #744 

---

## 🛠 Changes Made

- Fixed: Search button breaking layout when viewport width is below 900px on the home page search bar
- Updated: Set `align-items: stretch` on `.wander-search-bar` at ≤900px so column layout children span full width
- Updated: Added `width: 100%`, `flex: 1 1 100%`, and `justify-content: center` on `.wander-search-btn` for mobile viewports
- Updated: Reset `.wander-sf` height to `auto` on mobile for consistent stacked field layout

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Open home page at viewport width > 900px → search bar displays in row layout with visible, clickable Search button
  - Test case 2: Resize browser window to width below 900px → search button stretches full-width, remains visible and functional
  - Test case 3: Submit search form on mobile viewport → search works as expected with no layout overflow or clipping
---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [ ] Have starred the repository ⭐
- [ ] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [ ] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes (If any)

Fix applied in `client/src/pages/Home.css`. The root cause was `align-items: center` on the flex search bar preventing the button from stretching when the layout switched to column direction below 900px.

---
