### PR TITLE
fix: correct static asset paths in index.html metadata tags

### DIFF
--- a/travel-plans-client/client/public/index.html
+++ b/travel-plans-client/client/public/index.html
@@ -6,25 +6,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
 
-    <!-- Primary meta description -->
     <meta
       name="description"
       content="PackGo – Your smart travel planning companion. Plan trips, track expenses, manage packing lists, and explore destinations across India."
     />
 
-    <!-- Open Graph / WhatsApp / LinkedIn / Facebook previews -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="PackGo - Travel Planner" />
     <meta property="og:description" content="PackGo – Your smart travel planning companion. Plan trips, track expenses, manage packing lists, and explore destinations across India." />
-    <meta property="og:image" content="%PUBLIC_URL%/logo512.png" />
+    <meta property="og:image" content="/logo512.png" />
 
-    <!-- Twitter / X card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="PackGo - Travel Planner" />
     <meta name="twitter:description" content="PackGo – Your smart travel planning companion. Plan trips, track expenses, manage packing lists, and explore destinations across India." />
-    <meta name="twitter:image" content="%PUBLIC_URL%/logo512.png" />
+    <meta name="twitter:image" content="/logo512.png" />
 
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>PackGo - Travel Planner</title>
   </head>


### PR DESCRIPTION


## 📌 Linked Issue

Closes #973 

## 📌 Description
This PR resolves an issue in `public/index.html` where static asset references inside custom metadata attributes (`content="..."`) were failing to compile during the production build pipeline. 

By replacing the uncompiled `%PUBLIC_URL%` templates with clean, root-relative paths, we ensure that metadata preview images (`og:image`, `twitter:image`) and the `apple-touch-icon` resolve properly when scraped by external platforms.

## 🛠️ Changes Made
* Updated `<meta property="og:image" ...>` to use root-relative path `/logo512.png`.
* Updated `<meta name="twitter:image" ...>` to use root-relative path `/logo512.png`.
* Updated `<link rel="apple-touch-icon" ...>` to use root-relative path `/logo192.png`.
