### PR TITLE
1000 fix: scroll to top when navigating to About page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -22,6 +22,7 @@ import NotFound from "./pages/NotFound";
 import Contact from "./pages/contact"; // ✅ ADDED
 import PrivateRoute from "./components/PrivateRoute";
 import ScrollButtons from "./components/ScrollButtons";
+import ScrollToTop from "./components/ScrollToTop";
 import { loadUser } from "./redux/actions/authActions";
 import About from "./pages/About"; // <-- ADD THIS IMPORT
 import TravelChecklist from "./components/TravelChecklist";
@@ -36,6 +37,7 @@ function App() {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <Router>
+          <ScrollToTop />
           <div className="App">
             <Routes>
               {/* Protected Dashboard */}

--- a/client/src/components/ScrollLink.js
+++ b/client/src/components/ScrollLink.js
@@ -1,0 +1,21 @@
+import { Link, useLocation } from "react-router-dom";
+
+function normalizePath(path) {
+  if (typeof path !== "string") return "";
+  return path.replace(/\/$/, "") || "/";
+}
+
+export default function ScrollLink({ to, onClick, ...props }) {
+  const location = useLocation();
+  const targetPath = typeof to === "string" ? to : (to?.pathname ?? "");
+
+  const handleClick = (e) => {
+    if (normalizePath(location.pathname) === normalizePath(targetPath)) {
+      e.preventDefault();
+      window.scrollTo(0, 0);
+    }
+    onClick?.(e);
+  };
+
+  return <Link to={to} onClick={handleClick} {...props} />;
+}

--- a/client/src/components/ScrollToTop.js
+++ b/client/src/components/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/client/src/pages/About.js
+++ b/client/src/pages/About.js
@@ -1,6 +1,7 @@
 // src/pages/About.js
 import React from "react";
 import { Link } from "react-router-dom";
+import ScrollLink from "../components/ScrollLink";
 import { FaFacebook, FaInstagram, FaTwitter } from "react-icons/fa";
 import "./Home.css"; // reuse same styles
 
@@ -158,9 +159,9 @@ const About = () => {
       <footer className="wander-footer">
         <div className="wander-footer-top">
           <div className="wander-footer-brand">
-            <Link to="/" className="wander-footer-logo">
+            <ScrollLink to="/" className="wander-footer-logo">
               Pack<span>Go</span>
-            </Link>
+            </ScrollLink>
             <p>
               Discover breathtaking destinations, curated travel experiences,
               and unforgettable journeys with PackGo Travel.
@@ -175,15 +176,15 @@ const About = () => {
             </div>
             <div className="wander-footer-col">
               <h4>Company</h4>
-              <Link to="/about">About</Link>
-              <Link to="/careers">Careers</Link>
-              <Link to="/contact">Contact</Link>
+              <ScrollLink to="/about">About</ScrollLink>
+              <ScrollLink to="/careers">Careers</ScrollLink>
+              <ScrollLink to="/contact">Contact</ScrollLink>
             </div>
             <div className="wander-footer-col">
               <h4>Support</h4>
-              <Link to="/help">Help Center</Link>
-              <Link to="/privacy">Privacy Policy</Link>
-              <Link to="/terms">Terms & Conditions</Link>
+              <ScrollLink to="/help">Help Center</ScrollLink>
+              <ScrollLink to="/privacy">Privacy Policy</ScrollLink>
+              <ScrollLink to="/terms">Terms & Conditions</ScrollLink>
             </div>
           </div>
         </div>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import ScrollLink from "../components/ScrollLink";
 import { useSelector, useDispatch } from "react-redux";
 import "./Home.css";
 import api from "../services/api";
@@ -1143,9 +1144,9 @@ const Home = () => {
       <footer className="wander-footer">
         <div className="wander-footer-top">
           <div className="wander-footer-brand">
-            <Link to="/" className="wander-footer-logo">
+            <ScrollLink to="/" className="wander-footer-logo">
               Pack<span>Go</span>
-            </Link>
+            </ScrollLink>
             <p>
               Discover breathtaking destinations, curated travel experiences,
               and unforgettable journeys with PackGo Travel.
@@ -1163,17 +1164,17 @@ const Home = () => {
 
             <div className="wander-footer-col">
               <h4>Company</h4>
-              <Link to="/about">About</Link>
-              <Link to="/careers">Careers</Link>
-              <Link to="/contact">Contact</Link>
-              <Link to="/travel-checklist">Travel Checklist</Link>
+              <ScrollLink to="/about">About</ScrollLink>
+              <ScrollLink to="/careers">Careers</ScrollLink>
+              <ScrollLink to="/contact">Contact</ScrollLink>
+              <ScrollLink to="/travel-checklist">Travel Checklist</ScrollLink>
             </div>
 
             <div className="wander-footer-col">
               <h4>Support</h4>
-              <Link to="/help">Help Center</Link>
-              <Link to="/privacy">Privacy Policy</Link>
-              <Link to="/terms">Terms & Conditions</Link>
+              <ScrollLink to="/help">Help Center</ScrollLink>
+              <ScrollLink to="/privacy">Privacy Policy</ScrollLink>
+              <ScrollLink to="/terms">Terms & Conditions</ScrollLink>
             </div>
           </div>
         </div>


### PR DESCRIPTION

## 📌 Linked Issue

Closes #1000


## 🛠 Changes Made

Added: A reusable ScrollToTop component to handle scroll position on route changes.
Fixed: The footer About link now navigates to the About page with the viewport positioned at the top instead of preserving the previous scroll position.
Updated: Integrated the ScrollToTop component into the application's routing structure.
---

## 🧪 Testing

- [ X] Tested manually (describe below):
- on local computer

---

This change improves navigation consistency by ensuring users always start at the top of the About page when navigating via the footer link.
