### PR TITLE
Add weather provider and last updated metadata

### DIFF
--- a/client/src/pages/dashboard/WeatherView.js
+++ b/client/src/pages/dashboard/WeatherView.js
@@ -282,6 +282,27 @@ const WeatherView = () => {
                   </Box>
                 </Grid>
               </Grid>
+              {/* Weather metadata */}
+              <Box sx={{ mt: 3 }}>
+                {/* Weather API provider */}
+                <Typography
+                  variant="caption"
+                  display="block"
+                  sx={{ opacity: 0.9 }}
+                >
+                  Source: {currentWeather?.provider || "OpenWeather"}
+                </Typography>
+
+                {/* Last successful weather fetch */}
+                <Typography
+                  variant="caption"
+                  display="block"
+                  sx={{ opacity: 0.9 }}
+                >
+                  Last Updated:{" "}
+                  {fetchedAt ? new Date(fetchedAt).toLocaleTimeString() : "—"}
+                </Typography>
+              </Box>
             </Paper>
           </Grid>
 
@@ -315,12 +336,6 @@ const WeatherView = () => {
                 </Typography>
               )}
               <Box sx={{ mt: "auto", pt: 3 }}>
-                {/* ✅ Real fetchedAt timestamp */}
-                <Typography variant="caption" color="text.disabled">
-                  Last updated:{" "}
-                  {fetchedAt ? new Date(fetchedAt).toLocaleTimeString() : "—"}
-                </Typography>
-
                 {/* ✅ Manual refresh button */}
                 <Box mt={1}>
                   <Button

--- a/server/controllers/weatherController.js
+++ b/server/controllers/weatherController.js
@@ -18,6 +18,9 @@ exports.getCurrentWeather = async (req, res) => {
       humidity: response.data.main.humidity,
       windSpeed: response.data.wind.speed,
       timestamp: response.data.dt,
+
+      // Weather provider information
+      provider: "OpenWeather",
     };
 
     res.json(weatherData);


### PR DESCRIPTION

## 📌 Linked Issue

<!-- Use "Closes #123" to auto-close the issue when PR is merged -->

Closes #980 

---

## 🛠 Changes Made

- Added weather provider information (`OpenWeather`) to the weather API response.
- Added weather provider display in the Current Weather card.
- Added last updated timestamp display in the Current Weather card.
- Moved weather-related metadata from the Travel Tip section to the Current Weather section for better visibility.

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [ ] Tested manually (describe below):
### Verification Performed
- Confirmed weather provider (`OpenWeather`) is added to the API response.
- Confirmed weather provider is rendered in the Current Weather card.
- Confirmed the Last Updated timestamp is rendered using the existing `fetchedAt` state.
- Verified no unrelated files are included in the PR.
 
---

## 📸 UI Changes (if applicable)

| Before | After |
|---------|---------|
| Weather card displayed weather details only | Weather card now displays Source and Last Updated information |

---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [X] Added code comments

---

## ✅ Checklist

- [X] Created a new branch for PR
- [X] Have starred the repository ⭐
- [X] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [X] No console warnings/errors
- [X] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes (If any)

This enhancement improves transparency by allowing users to see the weather data provider and the freshness of the displayed weather information.
