### PR TITLE
fix: resolved google auth button overflow on mobile viewports

### DIFF
--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -54,10 +54,7 @@ const GoogleAuthSection = ({ onSuccess }) => {
       </Divider>
 
       {/* Container measured so we can feed exact px width to GoogleLogin */}
-      <Box
-        ref={containerRef}
-        sx={{ width: "100%", overflow: "hidden", mb: 3 }}
-      >
+      <Box ref={containerRef} sx={{ width: "100%", overflow: "hidden", mb: 3 }}>
         {buttonWidth !== null && (
           <GoogleLogin
             theme="outlined"

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { googleLogin, login } from "../redux/actions/authActions";
@@ -22,6 +22,58 @@ import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 
 import LoginIcon from "@mui/icons-material/Login";
 import PrimaryButton from "../components/PrimaryButton";
+
+/**
+ * Renders the Google Sign-In button and surrounding OR divider.
+ * Uses a ResizeObserver to measure available container width so that
+ * the GoogleLogin iframe never overflows its parent on any viewport.
+ */
+const GoogleAuthSection = ({ onSuccess }) => {
+  const containerRef = useRef(null);
+  const [buttonWidth, setButtonWidth] = useState(null);
+
+  const updateWidth = useCallback(() => {
+    if (containerRef.current) {
+      setButtonWidth(Math.floor(containerRef.current.clientWidth));
+    }
+  }, []);
+
+  useEffect(() => {
+    updateWidth();
+    const observer = new ResizeObserver(updateWidth);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [updateWidth]);
+
+  return (
+    <>
+      <Divider sx={{ my: 3 }}>
+        <Typography variant="body2" color="text.secondary">
+          OR
+        </Typography>
+      </Divider>
+
+      {/* Container measured so we can feed exact px width to GoogleLogin */}
+      <Box
+        ref={containerRef}
+        sx={{ width: "100%", overflow: "hidden", mb: 3 }}
+      >
+        {buttonWidth !== null && (
+          <GoogleLogin
+            theme="outlined"
+            width={buttonWidth}
+            shape="pill"
+            text="continue_with"
+            size="large"
+            onSuccess={onSuccess}
+            onError={() => console.log("Google Login failed")}
+            useOneTap
+          />
+        )}
+      </Box>
+    </>
+  );
+};
 
 const Login = () => {
   const [formData, setFormData] = useState({
@@ -292,50 +344,7 @@ const Login = () => {
                 Sign In
               </PrimaryButton>
 
-              <Divider sx={{ my: 3 }}>
-                <Typography variant="body2" color="text.secondary">
-                  OR
-                </Typography>
-              </Divider>
-
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  gap: 2,
-                  mb: 3,
-                }}
-              >
-                <Box sx={{ display: "flex", gap: 2 }}>
-                  <GoogleLogin
-                    theme="outlined"
-                    width={isMobile ? 360 : 500}
-                    shape="pill"
-                    text="continue_with"
-                    size="large"
-                    sx={{
-                      borderRadius: 2,
-                      py: 1,
-
-                      color: "#3f51b5",
-                      borderColor: "#3f51b5",
-                      "&:hover": {
-                        backgroundColor: "rgba(66,133,244,0.08)",
-                        borderColor: "#3f51b5",
-                      },
-                      "&:active": {
-                        backgroundColor: "#3f51b5",
-                        color: "#fff",
-                        transform: "scale(0.98)",
-                      },
-                    }}
-                    onSuccess={handleGoogleSuccess}
-                    onError={() => console.log("Google Login failed")}
-                    useOneTap
-                  />
-                </Box>
-              </Box>
+              <GoogleAuthSection onSuccess={handleGoogleSuccess} />
             </form>
           </Paper>
 

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -648,9 +648,7 @@ const Register = () => {
               </Box>
 
               {activeStep === 0 && (
-                <GoogleAuthSection
-                  onSuccess={handleGoogleSuccess}
-                />
+                <GoogleAuthSection onSuccess={handleGoogleSuccess} />
               )}
             </form>
           </Paper>

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { register, googleLogin } from "../redux/actions/authActions";
@@ -29,6 +29,55 @@ import ArrowBackIcon from "@mui/icons-material/West";
 
 import HowToRegIcon from "@mui/icons-material/HowToReg";
 import PrimaryButton from "../components/PrimaryButton";
+
+/**
+ * Renders the Google Sign-In button and surrounding OR divider.
+ * Uses a ResizeObserver to measure available container width so that
+ * the GoogleLogin iframe never overflows its parent on any viewport.
+ */
+const GoogleAuthSection = ({ onSuccess }) => {
+  const containerRef = useRef(null);
+  const [buttonWidth, setButtonWidth] = useState(null);
+
+  const updateWidth = useCallback(() => {
+    if (containerRef.current) {
+      setButtonWidth(Math.floor(containerRef.current.clientWidth));
+    }
+  }, []);
+
+  useEffect(() => {
+    updateWidth();
+    const observer = new ResizeObserver(updateWidth);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [updateWidth]);
+
+  return (
+    <>
+      <Divider sx={{ my: 4 }}>
+        <Typography variant="body2" color="text.secondary">
+          OR
+        </Typography>
+      </Divider>
+
+      {/* Container measured so we can feed exact px width to GoogleLogin */}
+      <Box ref={containerRef} sx={{ width: "100%", overflow: "hidden" }}>
+        {buttonWidth !== null && (
+          <GoogleLogin
+            theme="outlined"
+            width={buttonWidth}
+            shape="pill"
+            text="continue_with"
+            size="large"
+            onSuccess={onSuccess}
+            onError={() => console.log("Google Login failed")}
+            useOneTap
+          />
+        )}
+      </Box>
+    </>
+  );
+};
 
 const Register = () => {
   const [activeStep, setActiveStep] = useState(0);
@@ -599,51 +648,9 @@ const Register = () => {
               </Box>
 
               {activeStep === 0 && (
-                <>
-                  <Divider sx={{ my: 4 }}>
-                    <Typography variant="body2" color="text.secondary">
-                      OR
-                    </Typography>
-                  </Divider>
-
-                  <Box
-                    sx={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "center",
-                      gap: 2,
-                    }}
-                  >
-                    <Box sx={{ display: "flex", gap: 2 }}>
-                      <GoogleLogin
-                        theme="outlined"
-                        width={isMobile ? 360 : 500}
-                        shape="pill"
-                        text="continue_with"
-                        size="large"
-                        sx={{
-                          borderRadius: 2,
-                          py: 1,
-
-                          color: "#3f51b5",
-                          borderColor: "#3f51b5",
-                          "&:hover": {
-                            backgroundColor: "rgba(66,133,244,0.08)",
-                            borderColor: "#3f51b5",
-                          },
-                          "&:active": {
-                            backgroundColor: "#3f51b5",
-                            color: "#fff",
-                            transform: "scale(0.98)",
-                          },
-                        }}
-                        onSuccess={handleGoogleSuccess}
-                        onError={() => console.log("Google Login failed")}
-                        useOneTap
-                      />
-                    </Box>
-                  </Box>
-                </>
+                <GoogleAuthSection
+                  onSuccess={handleGoogleSuccess}
+                />
               )}
             </form>
           </Paper>


### PR DESCRIPTION
## 📌 Linked Issue

<!-- Use "Closes #123" to auto-close the issue when PR is merged -->

Closes #1039 

---

## 🛠 Changes Made

- Added: 
 
[ GoogleAuthSection sub-component in Login.js and Register.js that uses ResizeObserver to dynamically measure the available container width and feed it to the GoogleLogin button's width prop. ]

- Fixed: 
 
[ Google Sign-In button overflowing its container on mobile viewports, caused by a hardcoded pixel width (360px) being passed directly to the GoogleLogin iframe, which ignores all CSS/flexbox constraints. ]

- Updated: 
 
[ Login.js and Register.js to import useRef and useCallback hooks required by the new component. ]

---

## 🧪 Testing

- [X] Ran unit tests (`npm test`)
- [X] Tested manually (describe below):
 
   1. Test case 1: 
   Open /register on a 375px wide mobile viewport (e.g. iPhone SE in DevTools) → Google Sign-In button fits within the form card without any horizontal overflow or scrollbar.
   2. Test case 2:
   Open /login on a 375px wide mobile viewport → Google Sign-In button fits within the form card without any horizontal overflow or scrollbar.
   3. Test case 3:
   Resize the browser window from desktop (~1280px) down to mobile (~320px) while on /register or /login → Google button continuously adapts its width to match the container; no overflow occurs at any breakpoint.
   4. Test case 4:
   Click the Google Sign-In button on /register → Google OAuth popup appears and authentication flow completes successfully (no regression in functionality).
   5. Test case 5:
   Click the Google Sign-In button on /login → Google OAuth popup appears and authentication flow completes successfully (no regression in functionality).

---

## 📸 UI Changes (if applicable)

| Before  | 
| ------- | 

<img width="3420" height="1904" alt="yess 2026-06-12 at 5 23 27 AM" src="https://github.com/user-attachments/assets/cf171704-683f-4bcb-a525-18cc889f7c38" />

| After   |
| ------- |

<img width="3420" height="1904" alt="yess 2026-06-12 at 1 37 30 PM" src="https://github.com/user-attachments/assets/539b75bd-1ed9-4e2d-baaa-a53b1b36219c" />

---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [X] Added code comments

---

## ✅ Checklist

- [X] Created a new branch for PR
- [X] Have starred the repository ⭐
- [X] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [X] No console warnings/errors
- [X] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes (If any)

<!-- Optional: Deployment needs, breaking changes, etc. -->
