### PR TITLE
fix: reset edit trip form and validate trip dates

### DIFF
--- a/client/src/pages/dashboard/TripDetail.js
+++ b/client/src/pages/dashboard/TripDetail.js
@@ -178,6 +178,12 @@ const TripDetail = () => {
 
   const handleEditTrip = (e) => {
     e.preventDefault();
+
+    if (new Date(editForm.endDate) < new Date(editForm.startDate)) {
+      toast.error("End date cannot be earlier than start date");
+      return;
+    }
+
     dispatch(updateTrip(id, editForm));
     setEditOpen(false);
   };
@@ -255,7 +261,24 @@ const TripDetail = () => {
           </Tooltip>
           <Tooltip title="Edit Trip">
             <IconButton
-              onClick={() => setEditOpen(true)}
+              onClick={() => {
+                setEditForm({
+                  destination: currentTrip.destination || "",
+                  startDate: currentTrip.startDate
+                    ? new Date(currentTrip.startDate)
+                        .toISOString()
+                        .split("T")[0]
+                    : "",
+                  endDate: currentTrip.endDate
+                    ? new Date(currentTrip.endDate).toISOString().split("T")[0]
+                    : "",
+                  description: currentTrip.description || "",
+                  budget: currentTrip.budget || 0,
+                  status: currentTrip.status || "planned",
+                });
+
+                setEditOpen(true);
+              }}
               color="primary"
               sx={{ bgcolor: "primary.light" }}
             >
@@ -859,7 +882,12 @@ const TripDetail = () => {
                   fullWidth
                   type="date"
                   label="End Date"
-                  slotProps={{ inputLabel: { shrink: true } }}
+                  slotProps={{
+                    inputLabel: { shrink: true },
+                    htmlInput: {
+                      min: editForm.startDate,
+                    },
+                  }}
                   value={editForm.endDate || ""}
                   onChange={(e) =>
                     setEditForm({ ...editForm, endDate: e.target.value })


### PR DESCRIPTION
## 📌 Linked Issue

Closes #1081

---

## 🛠 Changes Made

- Added client-side validation to prevent users from saving a trip when the End Date is earlier than the Start Date.
- Reset the Edit Trip form with the latest saved trip data whenever the modal is reopened.
- Restricted the End Date field to dates on or after the selected Start Date.
- Fixed an issue where invalid, unsaved form data persisted after a failed trip update.

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Set End Date earlier than Start Date and clicked Save Changes. Verified that validation prevented the update and displayed an error message.
  - Test case 2: Closed and reopened the Edit Trip modal after a failed update attempt. Verified that the form displayed the last saved trip data.
  - Test case 3: Verified that End Date cannot be selected earlier than the chosen Start Date.

---

## 📸 UI Changes (if applicable)

| Before | After |
|---------|---------|
| Invalid dates remained in the Edit Trip modal after a failed update | Edit Trip modal reloads the latest saved trip data when reopened |
| Users could attempt to save trips with End Date before Start Date | Invalid date combinations are prevented before submission |

---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes

This PR improves the Edit Trip user experience by preventing invalid date submissions and ensuring that unsaved invalid form data is not retained when the modal is reopened.