### PR TITLE
fix: improve active navigation visibility and hover states

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -81,8 +81,10 @@ html {
   font-weight: 500;
   color: var(--ocean);
   opacity: 0.7;
-  transition: opacity 0.2s;
   letter-spacing: 0.3px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  transition: all 0.2s ease;
 }
 
 .wander-nav-links a:hover {
@@ -90,11 +92,13 @@ html {
 }
 
 .wander-nav-active {
-  color: var(--ocean) !important;
+  background: var(--ocean);
+  color: white !important;
   opacity: 1 !important;
   font-weight: 700;
-  border-bottom: 2px solid var(--ocean);
-  padding-bottom: 2px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(26, 74, 107, 0.25);
 }
 
 .wander-nav-log-in {
@@ -512,23 +516,23 @@ html {
 }
 
 .wander-see-all {
-  font-size: 0.85rem;
-  color: var(--mist);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: border-color 0.2s;
+  background: var(--ocean);
+  color: white;
+  border: none;
+  padding: 10px 18px;
+  border-radius: 999px;
   cursor: pointer;
-  background: none;
-  border-top: none;
-  border-left: none;
-  border-right: none;
   font-family: "DM Sans", sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: all 0.25s ease;
+  box-shadow: 0 4px 12px rgba(26, 74, 107, 0.2);
 }
 
 .wander-see-all:hover {
-  border-bottom-color: var(--mist);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(26, 74, 107, 0.3);
 }
-
 /* ═══ DESTINATIONS GRID ═══ */
 .wander-dest-grid {
   display: grid;


### PR DESCRIPTION
## Linked Issue

Closes #1193

---

## Changes Made

- Added: A more prominent pill-style active navigation indicator.
- Fixed: Low-contrast active navigation state that was difficult to distinguish.
- Updated: Navigation hover effects to provide clearer visual feedback.

---

## Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Navigated through homepage sections (Destinations, Features, Experiences) and verified the active navigation item is clearly highlighted.
  - Test case 2: Hovered over navigation items and verified that hover feedback is visually distinct from the active state.

---

## UI Changes (if applicable)

| Before | 

<img width="1448" height="313" alt="image" src="https://github.com/user-attachments/assets/6e681e50-1e8b-4641-85ca-8b7c268f611a" />

<img width="303" height="94" alt="image" src="https://github.com/user-attachments/assets/2486c5bc-df52-4519-b4e4-d5ba01c3ee9c" />



| After |

<img width="1444" height="191" alt="image" src="https://github.com/user-attachments/assets/fefc7ca2-e65c-4641-92b3-6feb386ceca9" />

<img width="335" height="91" alt="image" src="https://github.com/user-attachments/assets/d1bd8ac4-3737-4a05-ad75-0de2674f3cbc" />



| Active navigation item was indicated only by a subtle underline, making it difficult to identify. | Active navigation item is highlighted with a pill-style indicator and improved contrast for better visibility. |

---

## Documentation Updates

- [ ] Updated README/docs
- [ ] Added code comments

---

## Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## Additional Notes

This change improves navigation clarity and accessibility by making the active navigation item easier to identify while maintaining consistency with the existing design.