### PR TITLE
fix: add top margin to main container and align back-to-home link

### DIFF
--- a/client/src/components/TravelChecklist.jsx
+++ b/client/src/components/TravelChecklist.jsx
@@ -68,7 +68,7 @@ export default function TravelChecklist() {
           style={{
             position: "absolute",
             left: "clamp(16px, 4vw, 32px)",
-            top: "50%",
+            top: "25%",
             transform: "translateY(-50%)",
             color: "#fff",
             textDecoration: "none",
@@ -112,7 +112,7 @@ export default function TravelChecklist() {
       <div
         style={{
           maxWidth: "800px",
-          margin: "-24px auto 48px",
+          margin: "24px auto 48px",
           padding: "0 16px",
           display: "flex",
           flexDirection: "column",


### PR DESCRIPTION


## 📌 Linked Issue
 Fixes  #1208 


---

## 🛠 Changes Made

-  Added margin above the "Generate Checklist and reduced for "back to home" navigation


## 📸 UI Changes (if applicable)

### Before 

<img width="1920" height="1080" alt="Screenshot 2026-06-20 194252" src="https://github.com/user-attachments/assets/fabd411c-8fdf-42c3-92a2-301886cb990f" />


### After 

<img width="1920" height="1080" alt="Screenshot 2026-06-22 200929" src="https://github.com/user-attachments/assets/22b27528-1758-4dd2-96e0-a60cff24a9bb" />



---

