### PR TITLE
fix: validate expense dates within trip duration

### DIFF
--- a/server/controllers/expenseController.js
+++ b/server/controllers/expenseController.js
@@ -131,10 +131,10 @@ exports.updateExpense = async (req, res) => {
 
     const trip = await Trip.findById(expense.trip);
     if (!trip) {
-  return res.status(404).json({
-    msg: "Associated trip not found.",
-  });
-}
+      return res.status(404).json({
+        msg: "Associated trip not found.",
+      });
+    }
 
     const { amount, currency, category, description, date } = req.body;
 

--- a/server/controllers/expenseController.js
+++ b/server/controllers/expenseController.js
@@ -36,7 +36,21 @@ exports.createExpense = async (req, res) => {
     if (!tripExists) {
       return res.status(404).json({ msg: "Trip not found or unauthorized" });
     }
+    const expenseDate = new Date(date || Date.now());
 
+    if (isNaN(expenseDate.getTime())) {
+      return res.status(400).json({
+        msg: "Invalid expense date.",
+      });
+    }
+    if (
+      expenseDate < tripExists.startDate ||
+      expenseDate > tripExists.endDate
+    ) {
+      return res.status(400).json({
+        msg: `Expense date must be between ${tripExists.startDate.toDateString()} and ${tripExists.endDate.toDateString()}.`,
+      });
+    }
     const newExpense = new Expense({
       user: req.user.id,
       trip,
@@ -44,7 +58,7 @@ exports.createExpense = async (req, res) => {
       currency,
       category,
       description,
-      date: date || Date.now(),
+      date: expenseDate,
     });
 
     const expense = await newExpense.save();
@@ -115,6 +129,13 @@ exports.updateExpense = async (req, res) => {
       return res.status(403).json({ message: "Access denied" });
     }
 
+    const trip = await Trip.findById(expense.trip);
+    if (!trip) {
+  return res.status(404).json({
+    msg: "Associated trip not found.",
+  });
+}
+
     const { amount, currency, category, description, date } = req.body;
 
     // Validate amount if provided: must be a positive number
@@ -133,7 +154,23 @@ exports.updateExpense = async (req, res) => {
     if (currency) expenseFields.currency = currency;
     if (category) expenseFields.category = category;
     if (description) expenseFields.description = description;
-    if (date) expenseFields.date = date;
+    if (date) {
+      const expenseDate = new Date(date);
+
+      if (isNaN(expenseDate.getTime())) {
+        return res.status(400).json({
+          msg: "Invalid expense date.",
+        });
+      }
+
+      if (expenseDate < trip.startDate || expenseDate > trip.endDate) {
+        return res.status(400).json({
+          msg: `Expense date must be between ${trip.startDate.toDateString()} and ${trip.endDate.toDateString()}.`,
+        });
+      }
+
+      expenseFields.date = expenseDate;
+    }
 
     expense = await Expense.findOneAndUpdate(
       { _id: req.params.id, user: req.user.id },


### PR DESCRIPTION
## 📌 Linked Issue

Closes #1218

---

## 🛠 Changes Made

- Added validation for expense dates during expense creation.
- Added validation for expense dates during expense updates.
- Added invalid date checks.
- Added clear error messages showing the allowed trip date range.

---

## 🧪 Testing

- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Created an expense before trip start date → API returned 400 validation error.
  - Test case 2: Created an expense within trip date range → Expense created successfully.
  - Test case 3: Updated an expense with a date outside trip duration → API returned 400 validation error.
  - Test case 4: Updated an expense with a valid date → Expense updated successfully.

---

## 📸 UI Changes (if applicable)

N/A (Backend validation fix)

---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] No console warnings/errors related to this change
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes

Implemented validation to ensure:

trip.startDate <= expenseDate <= trip.endDate

Validation is applied during both expense creation and expense update operations.