### PR TITLE
UI Bug: Spending Allocation card title overlaps with wallet icon

### DIFF
--- a/client/src/pages/dashboard/ExpensesView.js
+++ b/client/src/pages/dashboard/ExpensesView.js
@@ -1099,6 +1099,7 @@ const ExpensesView = () => {
                   height: 120,
                   flexDirection: "column",
                   gap: 1.5,
+                  mt: 1.5,
                 }}
               >
                 <Box


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1190 

## 🛠 Changes Made

* Fixed the layout issue in the Spending Allocation card.
* Adjusted the spacing and alignment between the wallet icon and the "Spending Allocation" heading.
* Prevented the icon from overlapping the title when no spending data is available.

## 🧪 Testing

* [x] Tested manually

### Test Case

1. Logged into the application.
2. Navigated to the Expenses page.
3. Ensured there was no spending data.
4. Verified that the wallet icon, title, and message are properly aligned.
5. Confirmed that there is no overlap between the icon and heading.

## 🎨 UI Changes

### Before
<img width="370" height="284" alt="image" src="https://github.com/user-attachments/assets/5dd0999a-753a-4351-8430-c02765438b34" />



### After

<img width="376" height="392" alt="image" src="https://github.com/user-attachments/assets/b0909053-48fe-4980-bd96-37e84c81ae5d" />

## ✅ Checklist

* [x] Created a new branch for PR
* [x] No console warnings/errors related to this change
* [x] Tested the fix locally
