### PR TITLE
fix: show true budget utilization percentage on overspend (#1314)

### DIFF
--- a/client/src/pages/dashboard/TripDetail.js
+++ b/client/src/pages/dashboard/TripDetail.js
@@ -497,8 +497,7 @@ const TripDetail = () => {
                   fontWeight={700}
                   color={budgetPercent > 90 ? "error.main" : "success.main"}
                 >
-                  {budgetPercent.toFixed(1)}%
-                  {isOverBudget && " (Over Budget)"}
+                  {budgetPercent.toFixed(1)}%{isOverBudget && " (Over Budget)"}
                 </Typography>
               </Box>
               <LinearProgress

--- a/client/src/pages/dashboard/TripDetail.js
+++ b/client/src/pages/dashboard/TripDetail.js
@@ -132,9 +132,9 @@ const TripDetail = () => {
     ? expenses.reduce((acc, e) => acc + e.amount, 0)
     : 0;
   const budgetPercent =
-    currentTrip?.budget > 0
-      ? Math.min((totalSpent / currentTrip.budget) * 100, 100)
-      : 0;
+    currentTrip?.budget > 0 ? (totalSpent / currentTrip.budget) * 100 : 0;
+  const budgetProgressValue = Math.min(budgetPercent, 100);
+  const isOverBudget = budgetPercent > 100;
 
   const tripDataForBudget = {
     destination: currentTrip?.destination || currentTrip?.name || "",
@@ -498,11 +498,12 @@ const TripDetail = () => {
                   color={budgetPercent > 90 ? "error.main" : "success.main"}
                 >
                   {budgetPercent.toFixed(1)}%
+                  {isOverBudget && " (Over Budget)"}
                 </Typography>
               </Box>
               <LinearProgress
                 variant="determinate"
-                value={budgetPercent}
+                value={budgetProgressValue}
                 color={
                   budgetPercent > 90
                     ? "error"
@@ -510,13 +511,28 @@ const TripDetail = () => {
                       ? "warning"
                       : "success"
                 }
-                sx={{ height: 10, borderRadius: 5 }}
+                sx={{
+                  height: 10,
+                  borderRadius: 5,
+                  ...(isOverBudget && {
+                    "& .MuiLinearProgress-bar": {
+                      backgroundImage:
+                        "repeating-linear-gradient(45deg, rgba(255,255,255,0.3) 0, rgba(255,255,255,0.3) 6px, transparent 6px, transparent 12px)",
+                    },
+                  }),
+                }}
               />
               <Box
                 sx={{ display: "flex", justifyContent: "space-between", mt: 1 }}
               >
-                <Typography variant="caption" color="text.secondary">
+                <Typography
+                  variant="caption"
+                  color={isOverBudget ? "error.main" : "text.secondary"}
+                  fontWeight={isOverBudget ? 700 : 400}
+                >
                   Spent: ₹{totalSpent.toLocaleString()}
+                  {isOverBudget &&
+                    ` (₹${(totalSpent - currentTrip.budget).toLocaleString()} over)`}
                 </Typography>
                 <Typography variant="caption" color="text.secondary">
                   Budget: ₹{(currentTrip.budget || 0).toLocaleString()}


### PR DESCRIPTION
### Description
Fixes #1314. The Budget Utilization card and its progress bar were
computing `budgetPercent` with `Math.min((totalSpent / budget) * 100, 100)`,
so any spend beyond the budget silently capped the display at 100%
with no visual indication of overspend.

This PR separates the *true* percentage (used for display text) from
the *clamped* value (used only to satisfy MUI's `LinearProgress`
0–100 requirement), and adds:
- The real percentage in the header (e.g. `133.3%`)
- An "(Over Budget)" label when over 100%
- A striped/patterned progress bar fill when over budget
- The exact overspend amount shown next to "Spent" (e.g. `₹1,600 (₹400 over)`)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that this doesn't break existing functionality