### PR TITLE
fix: added case-insensitive validation for identical flight locations

### DIFF
--- a/server/controllers/bookingController.js
+++ b/server/controllers/bookingController.js
@@ -99,7 +99,12 @@ exports.searchFlights = async (req, res) => {
       });
     }
 
-    // Add request-specific fields to the shared flight data
+    if (origin.trim().toLowerCase() === destination.trim().toLowerCase()) {
+      return res.status(400).json({
+        msg: "Origin and destination cities cannot be the same",
+      });
+    }
+
     const flights = mockFlights.map((f) => ({
       ...f,
       origin,
@@ -108,7 +113,6 @@ exports.searchFlights = async (req, res) => {
       currency: "USD",
     }));
 
-    // Apply budget filters
     let filteredFlights = flights;
 
     if (minBudget !== undefined && minBudget !== "") {


### PR DESCRIPTION

Closes the issue #1319

### Changes Made:
- Added a case-insensitive validation check to `searchFlights` controller.
- Sanitized strings using `.trim().toLowerCase()` to prevent matching locations regardless of spacing or capitalization.
- Returns a standard `400 Bad Request` status to securely block identical searches.

