### PR TITLE
Fix: Hero section rating badge and price card alignment (#1353)

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -323,7 +323,8 @@ html {
 .wander-price-tag {
   position: absolute;
   bottom: -1rem;
-  left: -1.5rem;
+  right: 1.5rem;
+  left: auto;
   background: var(--white);
   border-radius: 14px;
   padding: 1rem 1.25rem;
@@ -355,7 +356,8 @@ html {
 .wander-stat-tag {
   position: absolute;
   top: 1.5rem;
-  left: -1rem;
+  right: 1.5rem;
+  left: auto;
   background: var(--coral);
   border-radius: 12px;
   padding: 0.75rem 1rem;


### PR DESCRIPTION
## 📌 Linked Issue


---

## 🛠 Changes Made
- Fixed: Rating badge and price card were using inconsistent negative `left` offsets, causing misalignment relative to the hero image
- Updated: Both elements now anchored to `right` edge of hero image container for consistent alignment reference

---

## 🧪 Testing
- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Opened homepage, scrolled to hero section — rating badge and price card now align to right edge of destination image consistently
  - Test case 2: Checked responsive view (mobile/tablet) — elements still positioned correctly, no overflow

---


---

## 📝 Documentation Updates
- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes
No breaking changes. Pure CSS fix in `Home.css`.