### PR TITLE
fix: improve duplicate item validation in packing list (Fixes #1364)

### DIFF
--- a/client/src/pages/dashboard/PackingView.js
+++ b/client/src/pages/dashboard/PackingView.js
@@ -147,6 +147,7 @@ const PackingView = () => {
   const [confirmClear, setConfirmClear] = useState(false);
   const [showPacked, setShowPacked] = useState(true);
   const [newlyAdded, setNewlyAdded] = useState(null);
+  const [duplicateWarning, setDuplicateWarning] = useState("");
 
   useEffect(() => {
     if (trips && trips.length > 0 && !selectedTripId) {
@@ -164,12 +165,22 @@ const PackingView = () => {
   const handleAdd = useCallback(() => {
     const trimmed = itemName.trim();
     if (!trimmed || !selectedTripId) return;
+
+    const isDuplicate = (list?.items || []).some(
+      (item) => item.name.trim().toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (isDuplicate) {
+      setDuplicateWarning(`"${trimmed}" already exists in your packing list`);
+      return;
+    }
+
+    setDuplicateWarning("");
     dispatch(addPackingItem(selectedTripId, trimmed, itemCategory));
     setNewlyAdded(trimmed);
     setItemName("");
     setItemCategory("Other");
     setTimeout(() => setNewlyAdded(null), 1500);
-  }, [dispatch, selectedTripId, itemName, itemCategory]);
+  }, [dispatch, selectedTripId, itemName, itemCategory, list]);
 
   const handleKeyDown = (e) => {
     if (e.key === "Enter") {
@@ -644,7 +655,10 @@ const PackingView = () => {
                   size="medium"
                   label="Item name"
                   value={itemName}
-                  onChange={(e) => setItemName(e.target.value)}
+                  onChange={(e) => {
+                    setItemName(e.target.value);
+                    if (duplicateWarning) setDuplicateWarning("");
+                  }}
                   onKeyDown={handleKeyDown}
                   placeholder="e.g., Passport, Charger..."
                   InputProps={{ sx: { borderRadius: 3 } }}
@@ -718,6 +732,17 @@ const PackingView = () => {
               </Grid>
             </Grid>
           </Paper>
+
+          {duplicateWarning && (
+            <Alert
+              severity="warning"
+              variant="outlined"
+              onClose={() => setDuplicateWarning("")}
+              sx={{ mb: 3, borderRadius: 3 }}
+            >
+              {duplicateWarning}
+            </Alert>
+          )}
 
           {/* ── Category Filter Chips ────────────────────────────────────────── */}
           {total > 0 && (


### PR DESCRIPTION
## Description

Fixes #1364

This PR improves the packing list experience by adding client-side duplicate validation before sending the request to the backend.

The backend already prevents duplicate items using a case-insensitive, trimmed comparison. However, duplicate items were only rejected after the API request completed, resulting in unnecessary requests and delayed feedback.

### Changes

- Added client-side duplicate validation using the same normalization logic as the backend (`trim().toLowerCase()`).
- Added a dismissible warning `Alert` when a duplicate item is entered.
- Automatically clears the warning when the input changes.
- Preserved the existing backend validation as the source of truth.

### Testing

- ✅ `Shoes` → added
- ✅ `shoes` → duplicate warning
- ✅ `SHOES` → duplicate warning
- ✅ ` Shoes ` → duplicate warning
- ✅ `Shoe` → added
- ✅ `Shoes1` → added
- ✅ Empty input behavior unchanged

## Screenshot

**After Fix**

Shows the duplicate warning displayed immediately when a duplicate packing item is entered.

<img width="1566" height="903" alt="Screenshot 2026-07-11 011802" src="https://github.com/user-attachments/assets/2fa19736-f9ae-4c75-a410-9829264e7fa0" />
