### PR TITLE
fix: delete associated PackingList when a trip is deleted

### DIFF
--- a/server/controllers/tripController.js
+++ b/server/controllers/tripController.js
@@ -2,6 +2,7 @@ const crypto = require("crypto");
 const Trip = require("../models/Trip");
 const Destination = require("../models/Destination");
 const Expense = require("../models/Expense");
+const PackingList = require("../models/PackingList");
 
 /**
  * Escape special regex metacharacters in a string so it can be safely
@@ -168,8 +169,9 @@ exports.deleteTrip = async (req, res) => {
       return res.status(403).json({ message: "Access denied" });
     }
 
-    // Also delete all expenses for this trip
+    // Also delete all expenses and the packing list for this trip
     await Expense.deleteMany({ trip: req.params.id });
+    await PackingList.deleteOne({ trip: req.params.id });
     await trip.deleteOne();
     res.json({ msg: "Trip removed" });
   } catch (err) {


### PR DESCRIPTION
## 📌 Linked Issue
Closes #1292

---

## 🛠 Changes Made
- Fixed: `exports.deleteTrip` in `server/controllers/tripController.js` now also deletes the associated `PackingList` document before removing the trip, preventing orphaned records in the database

---

## 🧪 Testing
- [ ] Ran unit tests (`npm test`)
- [ ] Tested manually (describe below):
  - No existing test suite covers `deleteTrip`. Change follows the exact same pattern as the existing `Expense.deleteMany({ trip: req.params.id })` cleanup line, adapted to `deleteOne` since `PackingList` has a `unique: true` one-to-one relationship with `trip`. Reviewable by inspection.

---

## 📸 UI Changes (if applicable)
N/A — backend-only change

---

## 📝 Documentation Updates
- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist
- [x] Created a new branch for PR
- [ ] Have starred the repository ⭐
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes (If any)
Minimal two-line fix, no schema or route changes.