### PR TITLE
fix: budget calculator now refreshes when trip data changes while open

### DIFF
--- a/client/src/components/dashboard/BudgetCalculator.js
+++ b/client/src/components/dashboard/BudgetCalculator.js
@@ -119,7 +119,7 @@ const BudgetCalculator = ({ open, onClose, tripData, onSaveBudget }) => {
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, tripData?.destination, tripData?.duration, tripData?.travelers]);
 
   // ── Derived budget numbers (pure calculation, no API) ──────────────────────
   const result = useMemo(() => calculateBudget(inputs), [inputs]);


### PR DESCRIPTION
## 📌 Linked Issue
Closes #1363

---

## 🛠 Changes Made
- Fixed: Budget Calculator wasn't refreshing when trip data changed while the drawer was already open. The effect that syncs `tripData` into Redux only had `open` in its dependency array, so it never re-ran on data changes — only on open/close. Updated the dependency array to watch `tripData.destination`, `tripData.duration`, and `tripData.travelers` directly.

---

## 🧪 Testing
- [ ] Ran unit tests (`npm test`)
- [x] Tested manually (describe below):
  - Test case 1: Open Budget Calculator with initial trip data → confirm it still pre-fills correctly on open (no regression)
  - Test case 2: With calculator open, change trip destination/duration/travelers elsewhere → confirm budget values update live without closing and reopening the drawer

---

## 📸 UI Changes (if applicable)
No visual changes — same UI, now reacts correctly to data updates.

---

## 📝 Documentation Updates
- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

## 💡 Additional Notes (If any)
Minimal one-line fix — only the effect's dependency array changed, no other logic touched.