### PR TITLE
feat: add dark mode support to the application

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -97,6 +97,7 @@
       "version": "7.26.10",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -692,6 +693,7 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz",
       "integrity": "sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1499,6 +1501,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
       "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-module-imports": "^7.25.9",
@@ -2292,10 +2295,8 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-     
       "license": "MIT",
-
-
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2337,6 +2338,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3013,6 +3015,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
       "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
@@ -3766,6 +3769,7 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4304,6 +4308,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -4355,6 +4360,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4694,6 +4700,7 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4781,6 +4788,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5629,6 +5637,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -7513,6 +7522,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10152,6 +10162,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -11232,7 +11243,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -12273,6 +12285,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -13389,6 +13402,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13748,6 +13762,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13877,6 +13892,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13901,7 +13917,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "peer": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -13935,6 +13952,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -13957,6 +13975,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14217,7 +14236,8 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "peer": true
     },
     "node_modules/redux-persist": {
       "version": "6.0.0",
@@ -14538,6 +14558,7 @@
       "version": "2.79.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -14765,6 +14786,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16281,6 +16303,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16704,6 +16727,7 @@
       "version": "5.98.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -16771,6 +16795,7 @@
       "version": "4.15.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -17176,6 +17201,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -13,6 +13,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: #f5f7fa;
   color: #2d3748;
+  transition:
+    background-color 0.25s ease,
+    color 0.25s ease;
+}
+
+/* dark mode - html tag gets data-theme="dark" when toggled */
+:root[data-theme="dark"] body {
+  background-color: #0f1115;
+  color: #e8eaed;
 }
 
 a {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,9 +4,10 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import store, { persistor } from "./redux/store";
-import { ThemeProvider } from "@mui/material/styles";
+import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
-import theme from "./theme";
+import { getTheme } from "./theme";
+import ThemeProvider, { useTheme } from "./contexts/ThemeModeContext";
 import "./App.css";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -28,7 +29,7 @@ import ScrollButtons from "./components/ScrollButtons";
 import ScrollToTop from "./components/ScrollToTop";
 import { loadUser } from "./redux/actions/authActions";
 import { flushOfflineQueue } from "./redux/actions/offlineQueueActions";
-import About from "./pages/About"; // <-- ADD THIS IMPORT
+import About from "./pages/About";
 import TravelChecklist from "./components/TravelChecklist";
 import EmailVerification from "./pages/EmailVerification";
 
@@ -36,17 +37,17 @@ if (process.env.NODE_ENV === "development") {
   window.store = store;
 }
 
-function App() {
+function AppContent() {
+  const { darkMode } = useTheme();
+  const theme = getTheme(darkMode);
+
   useEffect(() => {
     store.dispatch(loadUser());
 
-    // Flush any items queued from a previous session if we're already online.
     if (navigator.onLine) {
       store.dispatch(flushOfflineQueue());
     }
 
-    // Background re-sync: once connectivity returns, flush queued
-    // offline mutations back to the backend in order.
     const handleOnline = () => {
       store.dispatch(flushOfflineQueue());
     };
@@ -57,7 +58,7 @@ function App() {
   return (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
-        <ThemeProvider theme={theme}>
+        <MuiThemeProvider theme={theme}>
           <CssBaseline />
           <Router>
             <ScrollToTop />
@@ -78,7 +79,7 @@ function App() {
                 <Route path="/travel-checklist" element={<TravelChecklist />} />
                 <Route path="/login" element={<Login />} />
                 <Route path="/register" element={<Register />} />
-                {/* ✅ Contact Route Added */}
+                {/* Contact Route Added */}
                 <Route path="/contact" element={<Contact />} />
                 <Route path="/terms" element={<TermsConditions />} />
                 <Route path="/privacy" element={<PrivacyPolicy />} />
@@ -101,7 +102,7 @@ function App() {
               <ScrollButtons />
             </div>
           </Router>
-        </ThemeProvider>
+        </MuiThemeProvider>
         <ToastContainer
           position="bottom-right"
           autoClose={3000}
@@ -114,4 +115,13 @@ function App() {
     </Provider>
   );
 }
+
+function App() {
+  return (
+    <ThemeProvider>
+      <AppContent />
+    </ThemeProvider>
+  );
+}
+
 export default App;

--- a/client/src/contexts/ThemeModeContext.js
+++ b/client/src/contexts/ThemeModeContext.js
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export const ThemeContext = createContext();
+
+function ThemeProvider(props) {
+  let savedTheme = localStorage.getItem("theme");
+
+  const [darkMode, setDarkMode] = useState(
+    savedTheme === "dark" ? true : false,
+  );
+
+  useEffect(() => {
+    if (darkMode === true) {
+      localStorage.setItem("theme", "dark");
+      document.documentElement.setAttribute("data-theme", "dark");
+    } else {
+      localStorage.setItem("theme", "light");
+      document.documentElement.setAttribute("data-theme", "light");
+    }
+  }, [darkMode]);
+
+  function toggleTheme() {
+    if (darkMode === true) {
+      setDarkMode(false);
+    } else {
+      setDarkMode(true);
+    }
+  }
+
+  return (
+    <ThemeContext.Provider value={{ darkMode, toggleTheme }}>
+      {props.children}
+    </ThemeContext.Provider>
+  );
+}
+
+export default ThemeProvider;
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -1378,3 +1378,149 @@ html {
   background: #ff7f5c;
   color: white;
 }
+
+/* ---------- dark mode styles ---------- */
+/* these only apply when data-theme="dark" is set on the html tag */
+
+:root[data-theme="dark"] .wander-page {
+  --wp-surface: #161a22;
+  --wp-surface-alt: #1c212b;
+  --wp-bg: #0f1115;
+  --wp-text: #e8eaed;
+  --wp-heading: #9cc2e8;
+  --wp-border: rgba(232, 234, 237, 0.14);
+
+  background: var(--wp-bg);
+  color: var(--wp-text);
+}
+
+/* ── Navigation ── */
+:root[data-theme="dark"] .wander-nav {
+  background: rgba(15, 17, 21, 0.92);
+  border-bottom: 0.5px solid var(--wp-border);
+}
+
+:root[data-theme="dark"] .wander-nav-scrolled {
+  background: rgba(15, 17, 21, 0.98);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+:root[data-theme="dark"] .wander-logo,
+:root[data-theme="dark"] .wander-nav-links a,
+:root[data-theme="dark"] .wander-nav-active,
+:root[data-theme="dark"] .wander-nav-log-in,
+:root[data-theme="dark"] .wander-nav-create-account,
+:root[data-theme="dark"] .wander-mobile-menu,
+:root[data-theme="dark"] .wander-price-val,
+:root[data-theme="dark"] .wander-recent-search-item,
+:root[data-theme="dark"] .wander-sf-val,
+:root[data-theme="dark"] .wander-section-title,
+:root[data-theme="dark"] .wander-feat-title,
+:root[data-theme="dark"] .wander-testi-heading,
+:root[data-theme="dark"] .wander-author-name,
+:root[data-theme="dark"] .wander-stat-box,
+:root[data-theme="dark"] .wander-stat-big {
+  color: var(--wp-heading);
+}
+
+:root[data-theme="dark"] .wander-nav-active {
+  border-bottom-color: var(--wp-heading);
+}
+
+:root[data-theme="dark"] .wander-nav-log-in,
+:root[data-theme="dark"] .wander-nav-create-account {
+  border-color: var(--wp-border);
+}
+
+/* toggle button style */
+.wander-theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid rgba(26, 74, 107, 0.2);
+  background: transparent;
+  color: var(--ocean);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.wander-theme-toggle:hover {
+  background-color: var(--coral);
+  border-color: var(--coral);
+  color: white;
+}
+
+:root[data-theme="dark"] .wander-theme-toggle {
+  border-color: var(--wp-border, rgba(232, 234, 237, 0.14));
+  color: #9cc2e8;
+}
+
+/* search bar */
+:root[data-theme="dark"] .wander-page .wander-search-bar {
+  background: var(--wp-surface) !important;
+  border-color: var(--wp-border) !important;
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.4) !important;
+}
+
+:root[data-theme="dark"] .wander-page .wander-sf {
+  border-color: var(--wp-border) !important;
+}
+
+:root[data-theme="dark"] .wander-page .wander-sf:hover {
+  background: rgba(232, 234, 237, 0.05);
+}
+
+:root[data-theme="dark"] .wander-page .wander-sf:focus-within {
+  background: rgba(232, 234, 237, 0.08);
+  box-shadow: inset 0 0 0 2px rgba(232, 234, 237, 0.2);
+}
+
+:root[data-theme="dark"] .wander-recent-searches {
+  background: var(--wp-surface);
+  border-color: var(--wp-border);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+}
+
+/* feature cards */
+:root[data-theme="dark"] .wander-features-section {
+  background: var(--wp-surface-alt);
+}
+
+:root[data-theme="dark"] .wander-feat-card {
+  background: var(--wp-surface);
+  border-color: var(--wp-border);
+}
+
+:root[data-theme="dark"] .wander-feat-card:hover {
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+:root[data-theme="dark"] .wander-feat-icon {
+  background: rgba(232, 234, 237, 0.08);
+}
+
+/* quiz box */
+:root[data-theme="dark"] .travel-quiz {
+  background: var(--wp-surface);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+  color: var(--wp-text);
+}
+
+/* smooth transition when switching theme */
+.wander-page,
+.wander-nav,
+.wander-search-bar,
+.wander-feat-card,
+.wander-recent-searches {
+  transition:
+    background-color 0.25s ease,
+    color 0.25s ease,
+    border-color 0.25s ease,
+    box-shadow 0.25s ease;
+}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -12,6 +12,8 @@ import FAQSection from "../components/FAQSection";
 import RecentlyViewed from "../components/RecentlyViewed";
 import { addRecentlyViewed } from "../utils/recentlyViewed";
 import TravellerSelector from "../components/TravellerSelector";
+import { useTheme } from "../contexts/ThemeModeContext";
+import { FiSun, FiMoon } from "react-icons/fi";
 
 /* ── REVIEWS DATA FOR CAROUSEL ────────────────────────────── */
 const REVIEWS = [
@@ -395,6 +397,8 @@ const Home = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { isAuthenticated } = useSelector((s) => s.auth);
+  // dark mode toggle - true means dark is on
+  const { darkMode, toggleTheme } = useTheme();
 
   const [destinations, setDestinations] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -600,33 +604,48 @@ const Home = () => {
           )}
         </ul>
 
-        {isAuthenticated ? (
-          <Link to="/dashboard">
-            <button className="wander-nav-cta">My Dashboard</button>
-          </Link>
-        ) : (
-          <div
-            style={{
-              display: "flex",
-              gap: "0.75rem",
-              alignItems: "center",
-            }}
+        <div
+          style={{
+            display: "flex",
+            gap: "0.75rem",
+            alignItems: "center",
+          }}
+        >
+          {/* button to switch between light and dark theme */}
+          <button
+            type="button"
+            className="wander-theme-toggle"
+            onClick={toggleTheme}
+            aria-label={
+              darkMode ? "Switch to light mode" : "Switch to dark mode"
+            }
+            title={darkMode ? "Switch to light mode" : "Switch to dark mode"}
           >
-            <Link to="/login">
-              <button className="wander-nav-log-in">Log In</button>
-            </Link>
+            {darkMode ? <FiSun size={18} /> : <FiMoon size={18} />}
+          </button>
 
-            <Link to="/register">
-              <button className="wander-nav-create-account">
-                Create Free Account
-              </button>
+          {isAuthenticated ? (
+            <Link to="/dashboard">
+              <button className="wander-nav-cta">My Dashboard</button>
             </Link>
+          ) : (
+            <>
+              <Link to="/login">
+                <button className="wander-nav-log-in">Log In</button>
+              </Link>
 
-            <Link to="/register">
-              <button className="wander-nav-cta">Book Now</button>
-            </Link>
-          </div>
-        )}
+              <Link to="/register">
+                <button className="wander-nav-create-account">
+                  Create Free Account
+                </button>
+              </Link>
+
+              <Link to="/register">
+                <button className="wander-nav-cta">Book Now</button>
+              </Link>
+            </>
+          )}
+        </div>
 
         <button
           className="wander-mobile-menu"

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,15 +1,17 @@
 import { createTheme } from "@mui/material/styles";
 
-const theme = createTheme({
+// theme settings for light mode
+const lightTheme = createTheme({
   palette: {
+    mode: "light",
     primary: {
-      main: "#3f51b5", // A modern indigo
+      main: "#3f51b5",
       light: "#757de8",
       dark: "#002984",
       contrastText: "#ffffff",
     },
     secondary: {
-      main: "#ff6e40", // A vibrant orange/coral
+      main: "#ff6e40",
       light: "#ffa06d",
       dark: "#c53d13",
       contrastText: "#ffffff",
@@ -37,30 +39,12 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: '"Poppins", "Roboto", "Helvetica", "Arial", sans-serif',
-    h1: {
-      fontWeight: 700,
-      fontSize: "2.5rem",
-    },
-    h2: {
-      fontWeight: 600,
-      fontSize: "2rem",
-    },
-    h3: {
-      fontWeight: 600,
-      fontSize: "1.75rem",
-    },
-    h4: {
-      fontWeight: 600,
-      fontSize: "1.5rem",
-    },
-    h5: {
-      fontWeight: 600,
-      fontSize: "1.25rem",
-    },
-    h6: {
-      fontWeight: 600,
-      fontSize: "1rem",
-    },
+    h1: { fontWeight: 700, fontSize: "2.5rem" },
+    h2: { fontWeight: 600, fontSize: "2rem" },
+    h3: { fontWeight: 600, fontSize: "1.75rem" },
+    h4: { fontWeight: 600, fontSize: "1.5rem" },
+    h5: { fontWeight: 600, fontSize: "1.25rem" },
+    h6: { fontWeight: 600, fontSize: "1rem" },
     button: {
       textTransform: "none",
       fontWeight: 500,
@@ -69,33 +53,6 @@ const theme = createTheme({
   shape: {
     borderRadius: 8,
   },
-  shadows: [
-    "none",
-    "0px 2px 4px rgba(0, 0, 0, 0.05)",
-    "0px 4px 6px rgba(0, 0, 0, 0.05)",
-    "0px 6px 8px rgba(0, 0, 0, 0.05)",
-    "0px 8px 12px rgba(0, 0, 0, 0.05)",
-    "0px 10px 14px rgba(0, 0, 0, 0.05)",
-    "0px 12px 16px rgba(0, 0, 0, 0.05)",
-    "0px 14px 18px rgba(0, 0, 0, 0.05)",
-    "0px 16px 20px rgba(0, 0, 0, 0.05)",
-    "0px 18px 22px rgba(0, 0, 0, 0.05)",
-    "0px 20px 24px rgba(0, 0, 0, 0.05)",
-    "0px 22px 26px rgba(0, 0, 0, 0.05)",
-    "0px 24px 28px rgba(0, 0, 0, 0.05)",
-    "0px 26px 30px rgba(0, 0, 0, 0.05)",
-    "0px 28px 32px rgba(0, 0, 0, 0.05)",
-    "0px 30px 34px rgba(0, 0, 0, 0.05)",
-    "0px 32px 36px rgba(0, 0, 0, 0.05)",
-    "0px 34px 38px rgba(0, 0, 0, 0.05)",
-    "0px 36px 40px rgba(0, 0, 0, 0.05)",
-    "0px 38px 42px rgba(0, 0, 0, 0.05)",
-    "0px 40px 44px rgba(0, 0, 0, 0.05)",
-    "0px 42px 46px rgba(0, 0, 0, 0.05)",
-    "0px 44px 48px rgba(0, 0, 0, 0.05)",
-    "0px 46px 50px rgba(0, 0, 0, 0.05)",
-    "0px 48px 52px rgba(0, 0, 0, 0.05)",
-  ],
   components: {
     MuiButton: {
       styleOverrides: {
@@ -103,11 +60,76 @@ const theme = createTheme({
           borderRadius: 8,
           padding: "10px 24px",
         },
-        contained: {
-          boxShadow: "0px 4px 6px rgba(0, 0, 0, 0.1)",
-          "&:hover": {
-            boxShadow: "0px 6px 8px rgba(0, 0, 0, 0.15)",
-          },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+        },
+      },
+    },
+  },
+});
+
+const darkTheme = createTheme({
+  palette: {
+    mode: "dark",
+    primary: {
+      main: "#7986cb",
+      light: "#aab6fe",
+      dark: "#49599a",
+      contrastText: "#000000",
+    },
+    secondary: {
+      main: "#ff8a65",
+      light: "#ffbb93",
+      dark: "#c75b39",
+      contrastText: "#000000",
+    },
+    background: {
+      default: "#121212",
+      paper: "#1e1e1e",
+    },
+    text: {
+      primary: "#e8eaed",
+      secondary: "#a0a7b4",
+    },
+    success: {
+      main: "#5fd88a",
+    },
+    error: {
+      main: "#f97575",
+    },
+    warning: {
+      main: "#f6a75a",
+    },
+    info: {
+      main: "#5eb0f0",
+    },
+  },
+  typography: {
+    fontFamily: '"Poppins", "Roboto", "Helvetica", "Arial", sans-serif',
+    h1: { fontWeight: 700, fontSize: "2.5rem" },
+    h2: { fontWeight: 600, fontSize: "2rem" },
+    h3: { fontWeight: 600, fontSize: "1.75rem" },
+    h4: { fontWeight: 600, fontSize: "1.5rem" },
+    h5: { fontWeight: 600, fontSize: "1.25rem" },
+    h6: { fontWeight: 600, fontSize: "1rem" },
+    button: {
+      textTransform: "none",
+      fontWeight: 500,
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          padding: "10px 24px",
         },
       },
     },
@@ -115,33 +137,18 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           borderRadius: 12,
-          boxShadow: "0px 8px 12px rgba(0, 0, 0, 0.05)",
-        },
-      },
-    },
-    MuiPaper: {
-      styleOverrides: {
-        rounded: {
-          borderRadius: 12,
-        },
-        elevation1: {
-          boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.05)",
-        },
-        elevation2: {
-          boxShadow: "0px 6px 10px rgba(0, 0, 0, 0.05)",
-        },
-      },
-    },
-    MuiTextField: {
-      styleOverrides: {
-        root: {
-          "& .MuiOutlinedInput-root": {
-            borderRadius: 8,
-          },
         },
       },
     },
   },
 });
 
-export default theme;
+export function getTheme(darkMode) {
+  if (darkMode) {
+    return darkTheme;
+  } else {
+    return lightTheme;
+  }
+}
+
+export default lightTheme;


### PR DESCRIPTION
## Linked Issue

## Changes Made

- Added dark mode functionality
- Added dark mode toggle
- Updated UI components to support dark theme
- Ensured theme persists across pages (if applicable)

## Testing

- [x] Tested manually
- [ ] Ran unit tests

### Manual Testing
- Started both frontend and backend.
- Switched between light and dark mode.
- Verified UI updates correctly.

## Screenshots

Light Mode = <img width="2940" height="1756" alt="Image 24-07-26 at 10 00 AM" src="https://github.com/user-attachments/assets/8e877f8e-c75a-427c-abf5-943b2042a4e0" />

Dark Mode = <img width="2940" height="1758" alt="Image 24-07-26 at 10 00 AM" src="https://github.com/user-attachments/assets/8906d5e9-c4d2-4621-9c36-9d770fdb3b72" />

