### PR TITLE
fix: Add logout confirmation dialog to dashboard

### DIFF
--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -9,6 +9,12 @@ import {
 import { useSelector, useDispatch } from "react-redux";
 import {
   Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Drawer,
   List,
   ListItem,
@@ -60,6 +66,7 @@ const desktopDrawerWidth = 280;
 const Dashboard = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
+  const [logoutDialogOpen, setLogoutDialogOpen] = useState(false);
 
   const [notificationAnchor, setNotificationAnchor] = useState(null);
 
@@ -84,6 +91,15 @@ const Dashboard = () => {
 
   const handleLogout = () => {
     handleClose();
+    setLogoutDialogOpen(true);
+  };
+
+  const handleLogoutCancel = () => {
+    setLogoutDialogOpen(false);
+  };
+
+  const handleLogoutConfirm = () => {
+    setLogoutDialogOpen(false);
     dispatch(logout());
     navigate("/login");
   };
@@ -381,6 +397,34 @@ const Dashboard = () => {
                   Logout
                 </MenuItem>
               </Menu>
+
+              <Dialog
+                open={logoutDialogOpen}
+                onClose={handleLogoutCancel}
+                aria-labelledby="logout-dialog-title"
+                aria-describedby="logout-dialog-description"
+                fullWidth
+                maxWidth="xs"
+              >
+                <DialogTitle id="logout-dialog-title">
+                  Confirm Logout
+                </DialogTitle>
+                <DialogContent>
+                  <DialogContentText id="logout-dialog-description">
+                    Are you sure you want to log out?
+                  </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                  <Button onClick={handleLogoutCancel}>Cancel</Button>
+                  <Button
+                    onClick={handleLogoutConfirm}
+                    color="error"
+                    variant="contained"
+                  >
+                    Logout
+                  </Button>
+                </DialogActions>
+              </Dialog>
 
               <Menu
                 anchorEl={notificationAnchor}

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -279,6 +279,31 @@ const Dashboard = () => {
 
   return (
     <Box sx={{ display: "flex", minHeight: "100vh" }}>
+      <Dialog
+        open={logoutDialogOpen}
+        onClose={handleLogoutCancel}
+        aria-labelledby="logout-dialog-title"
+        aria-describedby="logout-dialog-description"
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle id="logout-dialog-title">Log out?</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="logout-dialog-description">
+            Are you sure you want to log out?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={handleLogoutCancel}>Cancel</Button>
+          <Button
+            onClick={handleLogoutConfirm}
+            color="error"
+            variant="contained"
+          >
+            Logout
+          </Button>
+        </DialogActions>
+      </Dialog>
       <Box
         component="nav"
         sx={{ width: { md: desktopDrawerWidth }, flexShrink: { md: 0 } }}
@@ -397,34 +422,6 @@ const Dashboard = () => {
                   Logout
                 </MenuItem>
               </Menu>
-
-              <Dialog
-                open={logoutDialogOpen}
-                onClose={handleLogoutCancel}
-                aria-labelledby="logout-dialog-title"
-                aria-describedby="logout-dialog-description"
-                fullWidth
-                maxWidth="xs"
-              >
-                <DialogTitle id="logout-dialog-title">
-                  Confirm Logout
-                </DialogTitle>
-                <DialogContent>
-                  <DialogContentText id="logout-dialog-description">
-                    Are you sure you want to log out?
-                  </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                  <Button onClick={handleLogoutCancel}>Cancel</Button>
-                  <Button
-                    onClick={handleLogoutConfirm}
-                    color="error"
-                    variant="contained"
-                  >
-                    Logout
-                  </Button>
-                </DialogActions>
-              </Dialog>
 
               <Menu
                 anchorEl={notificationAnchor}


### PR DESCRIPTION
## 📌 Linked Issue

Fixes #1410

---

## 🛠 Changes Made

- Added a Material UI logout confirmation dialog.
- Updated the logout flow to require user confirmation before logging out.

---

## 🧪 Testing

- [x] Ran unit tests (`npm test`)
- [x] Tested manually

---

## 📸 UI Changes (if applicable)
Before there was no dialog box with logout confirmation, i added that functionality now 
<img width="1801" height="707" alt="image" src="https://github.com/user-attachments/assets/24086ead-3279-47e1-8317-376ba3a78db6" />


---

## 📝 Documentation Updates

- [ ] Updated README/docs
- [ ] Added code comments

---

## ✅ Checklist

- [x] Created a new branch for PR
- [x] Have starred the repository ⭐
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] No console warnings/errors

---

## 💡 Additional Notes (If any)

Implemented a logout confirmation dialog using Material UI's `Dialog` component to prevent accidental logouts.