### PR TITLE
fix: correct error prop typo and reset otpResendAttempts on block expiry

### DIFF
--- a/client/src/redux/actions/authActions.js
+++ b/client/src/redux/actions/authActions.js
@@ -115,7 +115,7 @@ export const googleLogin =
     } catch (e) {
       dispatch({
         type: "AUTH_FAIL",
-        payload: e.rensponse?.data?.message || e.message,
+        payload: e.response?.data?.message || e.message,
       });
     }
   };

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -440,6 +440,11 @@ exports.requestEmailChange = async (req, res, next) => {
       });
     }
 
+    // Reset attempt counter if the previous block has expired
+    if (currentUser.otpBlockedUntil && new Date(currentUser.otpBlockedUntil).getTime() <= now) {
+      currentUser.otpResendAttempts = 0;
+    }
+
     // Check 60s cooldown
     if (currentUser.otpLastResent) {
       const lastResentTime = new Date(currentUser.otpLastResent).getTime();


### PR DESCRIPTION
## Bugs fixed

### 1. Google auth error message always generic (`authActions.js`)
Typo `e.rensponse` → `e.response` caused optional chaining to always yield undefined, so server error messages were never shown.

### 2. Email-change permanent re-block after 24h expires (`authController.js`)
`otpResendAttempts` was never reset when a 24-hour block expired, so the next request immediately re-blocked the user with no chance to ever change their email.