### PR TITLE
fix: remove duplicate resetPasswordExpire field and dead code

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -632,7 +632,5 @@ exports.getEmailChangeStatus = async (req, res, next) => {
     });
   } catch (err) {
     next(err);
-  }
-
-  console.log(typeof exports.verifyEmail);
+    }
 };

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -83,7 +83,6 @@ const UserSchema = new mongoose.Schema(
       type: String,
       default: "INR",
     },
-    resetPasswordExpire: Date,
     emailVerificationToken: {
       type: String,
       default: null,


### PR DESCRIPTION
Bugs fixed:
- User.js model had resetPasswordExpire defined twice (line 53 and 86)
- authController.js had unreachable console.log(typeof exports.verifyEmail) at end of getEmailChangeStatus