### PR TITLE
fix: TravelQuiz stuck in sticky nav, blocking page scroll

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -564,7 +564,6 @@ const Home = () => {
                   : ""
               }
             >
-              <TravelQuiz />
               Destinations
             </a>
           </li>
@@ -810,6 +809,7 @@ const Home = () => {
           </div>
         </div>
       </section>
+      <TravelQuiz />
 
       {/* ═══ SEARCH BAR ═══ */}
       <div className="wander-search-section">


### PR DESCRIPTION
## Problem
`<TravelQuiz />` was accidentally nested inside the sticky nav bar's anchor link (`<a href="#wander-dest-section">`) in `Home.js`. Since `.wander-nav` uses `position: sticky`, the entire quiz card got pinned to the top of the viewport along with the nav, blocking the page from scrolling normally.

## Fix
Moved `<TravelQuiz />` out of the nav and rendered it as its own section directly after the hero section, where it flows normally
with the rest of the page.

## Before 
<img width="1912" height="912" alt="Screenshot 2026-07-30 122832" src="https://github.com/user-attachments/assets/1509b403-5e6f-4f7c-936e-af989b4d9a1e" />

## After
<img width="1912" height="905" alt="Screenshot 2026-07-30 122842" src="https://github.com/user-attachments/assets/39322257-a939-4529-bebc-b1951d6cdd68" />

